### PR TITLE
Fix/1/floating point underflow

### DIFF
--- a/docs/design_notes.md
+++ b/docs/design_notes.md
@@ -1,0 +1,112 @@
+# MISDA: Comparison of Design Decisions & Technical Rationale
+
+*This document serves as the comprehensive "Brain Dump" of the MISDA project. It details the theoretical foundations, the specific implementation choices, and the historical rationales behind key architectural decisions. It is intended to bridge the context for drafting the formal academic paper.*
+
+---
+
+## 1. Core Philosophy: Structural Dimensionality
+
+### 1.1. The Problem with PCA
+Standard dimensionality reduction (PCA) relies on **Variance** explanation. In Multi-Objective Optimization (MOO), variance is often irrelevant; what matters is **Conflict Structure**. A variable with low variance might still be the "key" to a tradeoff.
+
+### 1.2. The MISDA Solution (Graph Theory)
+MISDA redefines reduction as a **Graph Theory** problem:
+*   **Nodes**: Objectives/Variables.
+*   **Edges**: "Significant Statistical Dependency" (Correlation > Critical Threshold).
+*   **Goal**: Find the **Maximal Independent Set (MIS)**.
+    *   If $A$ and $B$ are connected (Dependent), we only need one.
+    *   If $A$ and $B$ are not connected (Independent), we must keep both to preserve information.
+*   **Rationale**: The MIS is the smallest set of variables that can "cover" the entire variance space through observed dependencies.
+
+---
+
+## 2. Statistical Foundation: The Alpha ($\alpha$) Parameter
+
+The parameter $\alpha$ is often misunderstood as just a "p-value". In MISDA, it acts as a **Sensitivity Tuner** for the graph construction.
+
+### 2.1. Fisher Z-Transform
+We do not use raw correlations $r$. We use the Fisher Z-transform:
+$$ z = 0.5 \ln \left( \frac{1+r}{1-r} \right) $$
+$$ z_{stat} = \frac{z}{\sqrt{N-3}} $$
+This normalizes the distribution of correlations, allowing us to set thresholds based on sample size $N$ dynamically.
+
+### 2.2. The Alpha-Risk Spectrum
+*   **Standard View**: "Lower $\alpha$ means we are more sure."
+*   **MISDA View**: "Lower $\alpha$ means we satisfy **Fewer Edges**, which means **Less Reduction**, which means **Higher Safety**."
+    *   **High $\alpha$ (e.g., 0.05)**: Loose filter. Weak correlations accepted. Graph is dense. **Aggressive Reduction**. (Risk: False Positives/Over-reduction).
+    *   **Low $\alpha$ (e.g., $10^{-6}$)**: Strict filter. Only strong correlations accepted. Graph is sparse. **Conservative Retention**. (Safety: We keep variables unless proven redundant).
+
+---
+
+## 3. High-Dimensional Pathology ("The Sphere Paradox")
+
+One of the most critical insights of this project was the failure of standard heuristics in $M \ge 10$ dimensions.
+
+### 3.1. The Phenomenon
+In high-dimensional spaces (e.g., Hyperspheres like DTLZ2 $M=10$), random vectors tend to be **nearly orthogonal**.
+*   A random pair of vectors will have $r \approx 0$.
+*   A true geometric relationship in DTLZ2 also looks like $r \approx 0$ (due to the spherical manifold).
+
+### 3.2. The Failure of Heuristics
+Standard heuristics (like $\alpha=0.01$) assume that "Signal" is strong ($r > 0.3$) and "Noise" is weak ($r < 0.1$).
+In the Sphere Paradox, **Signal looks like Noise**.
+*   `analyze` with standard $\alpha$ sees "weak correlations" everywhere.
+*   It interprets them as "Dependencies" (if N is large) or "Independence" (if N is small) erratically.
+*   **Result**: It frequently over-reduces the set to 5-6 variables, destroying the manifold structure.
+
+### 3.3. The Solution: Adaptive Control Loop
+Since we cannot trust the *input* (p-values) to distinguish signal from noise, we must validate the *output* (Reconstruction Quality).
+*   **Open Loop (`static`)**: Guess $\alpha$ $\to$ Reduce. (Fails on Spheres).
+*   **Closed Loop (`adaptive`)**: Try $\alpha$ $\to$ Reduce $\to$ **Check SES** $\to$ Adjust $\alpha$.
+
+---
+
+## 4. Architectural Decisions & API Evolution
+
+### 4.1. The Logic of "Caution"
+We introduced a `caution` parameter [0, 1] to abstract $\alpha$ for users.
+*   *Initial Design*: Linearly mapped `caution` $\to$ `[alpha_min, alpha_max]`.
+*   *The Bug*: This meant `caution=1.0` (max) selected `alpha_max` (High Alpha = Aggressive). This was semantically inverted. "Maximum Caution" should not yield "Maximum Aggression".
+*   *The Fix (v0.3.0)*: Inverted the mapping.
+    *   `caution=1.0` $\to$ `alpha_min` (Conservative/Safe).
+    *   `caution=0.0` $\to$ `alpha_max` (Aggressive/Risky).
+
+### 4.2. Unified Strategy Pattern
+We initially built `misda.tune()` as a separate function.
+*   *Critique*: It fragmented the API. Users had to know *when* to switch functions.
+*   *Refactor (v0.3.0)*: Merged into `misda.analyze(method='adaptive')`.
+*   *Rationale*: It allows the user to simply state their **Intent** (`target_fidelity`) without changing their workflow. The library handles the complexity.
+
+### 4.3. Coverage Repair (`ensure_coverage`)
+Graph Independence algorithms (Bron-Kerbosch) maximize the *size* of the independent set but do not guarantee that the discarded nodes are actually "covered" (correlated) by the kept nodes.
+*   *Problem*: You could drop a variable that is independent of the kept set just because the algorithm was greedy.
+*   *Solution*: The `repair_mis_coverage` step. It iterates through discarded nodes and checks if `max(corr(discarded, kept)) < threshold`. If so, it forces the discarded node back into the set.
+*   *Infinite Loop Fix*: When $\alpha \to 0$, the threshold $r_{crit} \to 1.0$. If $r_{crit} > 0.999999$, nothing can ever "cover" anything. We clamped $r_{crit}$ to prevent infinite loops in the repair step.
+
+---
+
+## 5. Validation Logic
+
+### 5.1. Structural Evidence Score (SES)
+Why create a new metric instead of just $R^2$?
+*   **$F_{real}$**: How well we reconstruct the data using the selected subset.
+*   **$F_{null}$**: How well we reconstruct the data using a *random* subset of the same size.
+*   **SES**: $\frac{F_{real} - F_{null}}{1 - F_{null}}$.
+*   *Rationale*: A reconstruction of 0.8 might look good, but if a random subset also gives 0.8 (due to high collinearity), our specific selection isn't "special". SES measures the **Marginal Value** of our structural choice.
+
+### 5.2. Pareto Consistency
+For MOO, Linear Reconstruction is a proxy. The real truth is: **Does the reduced set generate the same Pareto Front?**
+*   **Precision (Safety)**: If a point is non-dominated in reduced space, is it non-dominated in full space? (1.0 = Safe).
+*   **Recall (Coverage)**: If a point is non-dominated in full space, is it non-dominated in reduced space? (1.0 = No Loss).
+
+---
+
+## 6. Summary for Paper
+
+**The central thesis of the MISDA paper should be:**
+
+> "Dimensionality Reduction in Many-Objective Optimization is not just about Variance (PCA); it is about **Conflict Structure** (Dependency). While Graph-Theoretic methods (like MISDA) successfully map this structure, they fail in high-dimensional hyperspheres due to statistical sparsity (The Sphere Paradox). We propose an **Adaptive, Closed-Loop Strategy** that utilizes Structural Evidence Score (SES) to dynamically tune the statistical sensitivity ($\alpha$), guaranteeing robust preservation of the Pareto Manifold even when signal-to-noise ratios approach zero."
+
+---
+*Created: 2026-01-05*
+*Author: Antigravity Agent (Brain Dump)*

--- a/misda.py
+++ b/misda.py
@@ -1884,7 +1884,7 @@ class MISDAResult:
         return fig
 
 
-def analyze(Y, method='static', caution=1.0, name=None, ensure_coverage=True, alpha=None, target_fidelity=0.95, max_iter=10):
+def analyze(Y, method='static', caution=0.5, name=None, ensure_coverage=True, alpha=None, target_fidelity=0.95, max_iter=10):
     """
     Executes the MISDA pipeline on dataset Y.
     
@@ -1896,6 +1896,7 @@ def analyze(Y, method='static', caution=1.0, name=None, ensure_coverage=True, al
         Y (np.ndarray or pd.DataFrame): Input data (N samples x M features).
         method (str): 'static' or 'adaptive'.
         caution (float): [Static Only] Conservatism level [0, 1]. 0 = Aggressive, 1 = Conservative.
+                         Defaults to 0.5 (Moderate).
         name (str): Optional name for the case.
         ensure_coverage (bool): If True, ensures result covers all variables.
         alpha (float, optional): [Static Only] Explicit alpha override.

--- a/misda.py
+++ b/misda.py
@@ -359,12 +359,26 @@ def alpha_from_r(r, n):
     r = float(abs(r))
     if r <= 0.0:
         return 1.0
-    if r >= 0.999999:
-        return 1e-12
-    z = np.arctanh(r)
-    se = 1.0 / np.sqrt(n - 3)
-    z_stat = z / se
-    p = 2.0 * (1.0 - stats.norm.cdf(abs(z_stat)))
+    
+    # Use survival function (sf = 1 - cdf) for better precision at tails
+    # Handle r -> 1.0 case implicitly via large z, clamping p at the end
+    if r >= 1.0 - 1e-15:
+        # Avoid arctanh(1) singularity
+        z_stat = np.inf
+    else:
+        z = np.arctanh(r)
+        se = 1.0 / np.sqrt(n - 3)
+        z_stat = z / se
+        
+    # Use sf instead of (1-cdf) to avoid precision loss near 0
+    p = 2.0 * stats.norm.sf(abs(z_stat))
+    
+    # Clamp to machine epsilon to represent "extremely significant" rather than 0
+    # This allows z_crit lookup to return a finite large number instead of inf
+    min_float = np.finfo(float).tiny
+    if p < min_float:
+        p = min_float
+        
     return float(p)
 
 def max_abs_corr(Y):
@@ -962,7 +976,11 @@ def misda_significance(Y, alpha=0.05, ensure_coverage=True, min_coverage=None):
     z = 0.5 * np.log((1 + corr) / (1 - corr))
     sigma_z = 1 / np.sqrt(N - 3)
     z_stat = z / sigma_z
-    z_crit = stats.norm.ppf(1 - alpha / 2)
+
+    # Use ISF (Inverse Survival Function) for better precision with small alpha
+    # Equivalent to ppf(1 - alpha/2) but avoids precision loss
+    # If alpha is extremely small (e.g. machine min), ISF returns large finite Z instead of inf.
+    z_crit = stats.norm.isf(alpha / 2)
     
     # Calculate correlation threshold corresponding to z_crit
     # z = z_crit * sigma_z
@@ -976,7 +994,7 @@ def misda_significance(Y, alpha=0.05, ensure_coverage=True, min_coverage=None):
     
     corr_report = report_significant_correlations(corr, z_stat, z_crit, label_prefix="f")
 
-    signif = (z_stat > z_crit)
+    signif = (z_stat >= z_crit)
     adjacency = signif.astype(int)
     np.fill_diagonal(adjacency, 0)
 


### PR DESCRIPTION
Not a regression, after all.
It seems that a parameter change in commit 6fb06d exposed a bug.

The default caution parameter was changed from 0.5 (Moderate) to 1.0 (Most Conservative).

caution=1.0 sets the significance threshold at the P-value of the single strongest observed correlation (alpha_min). This is extremely strict. This parameter change exposed a numerical bug.

For "Total Redundancy" cases (Case 2), the correlation is very high (near 0.997).
The P-value for this is around 10^(-300)
.
The previous code used 1.0 - cdf(z), which underflowed to 0.0 for such small probabilities.
With caution=1.0, this 0.0 was selected as the threshold, leading to z_crit = infinity, causing the algorithm to see no dependencies at all and fail to reduce dimensions (returning 20 instead of 1).
The Solution:

I updated misda.py to use sf (survival function) for precise P-value calculation, preventing the underflow. This fixed the "Total Redundancy" case.  I also reverted the default caution back to 0.5 for now.