### PR TITLE
Audit benchmark semantics and reference execution

### DIFF
--- a/.github/workflows/newapi.yml
+++ b/.github/workflows/newapi.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Full test suite
         run: pytest -q
       - name: Canonical scientific battery
-        run: python -m examples.benchmarks.run_benchmark --output /tmp/misda-benchmark.json
+        run: python -m examples.benchmarks.run_benchmark --strict --output /tmp/misda-benchmark.json
       - name: Comparative experiments
         run: python -m examples.benchmarks.run_comparative --output /tmp/misda-comparative.json

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -290,6 +290,16 @@ The benchmark must not feed truth back into `discover()`, `evaluate()`, or `rank
 
 Dimension declarations are not graph component-count declarations. A benchmark must never infer expected connected-component counts merely from expected structural or latent dimension.
 
+### 9.1 Benchmark declarations and scientific acceptance
+
+Structural/generating units and observed graph topology are distinct benchmark concepts. `blocks_expected` declares the intended structural or generating units; `components_expected` declares connected components. They may coincide in simple block cases, but one must never be inferred from the other by the benchmark evaluator.
+
+Expected benchmark mismatches are field-specific hypotheses about known methodological limitations, not blanket exemptions. A mismatch may be classified as `EXPECTED_DECLARATION_MISMATCH` only when the reason declared for that field is actually observed among MISDA's internal dimensional-support diagnostics for the result. If the declared diagnostic is absent, the mismatch remains an unexpected `DECLARATION_MISMATCH`.
+
+The canonical scientific benchmark execution follows the notebook reference: `N=300` with linear and Pareto evidence evaluated over the default cheap-family scope, i.e. all discovered candidates. `--quick` uses a reduced sample only as an execution smoke test and must not define or fail a scientific baseline.
+
+The acceptance workflow invokes the benchmark in strict mode. Strict mode fails only on unexpected declaration mismatches and must report the failing case, field, observed value, expected value, and reason. Expected diagnostic-backed mismatches remain visible in the artifact/report but do not fail the scientific gate.
+
 ## 10. Reporting and plotting
 
 Reports and plots are views over already stored state. They must not rerun scientific evaluation or consult benchmark truth.

--- a/examples/benchmarks/run_benchmark.py
+++ b/examples/benchmarks/run_benchmark.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import misda
 from misda.benchmark import (
     BenchmarkCase,
+    DECLARATION_MISMATCH,
     DEFAULT_SEED,
     FORMAT_VERSION,
     METHOD,
@@ -56,11 +57,7 @@ def run_benchmark(
         if serializer is not None:
             case = serializer(case_id, frame, truth, seed=seed)
         else:
-            declaration = BenchmarkCase.from_truth(
-                case_id,
-                truth,
-                adversarial=case_id == "case_05",
-            )
+            declaration = BenchmarkCase.from_truth(case_id, truth)
             mis_set = misda.discover(
                 frame,
                 name=truth["name"],
@@ -94,6 +91,15 @@ def run_benchmark(
     }
 
 
+def unexpected_mismatch_case_ids(artifact) -> tuple[str, ...]:
+    return tuple(
+        case["case_id"]
+        for case in artifact.get("cases", ())
+        if (case.get("assessment") or {}).get("status")
+        == DECLARATION_MISMATCH
+    )
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", type=Path, required=True)
@@ -118,6 +124,12 @@ def main() -> None:
         case_ids=set(args.case_ids) if args.case_ids else None,
     )
     write_json(artifact, args.output)
+    unexpected = unexpected_mismatch_case_ids(artifact)
+    if unexpected:
+        raise SystemExit(
+            "Unexpected benchmark declaration mismatch: "
+            + ", ".join(unexpected)
+        )
 
 
 if __name__ == "__main__":

--- a/examples/benchmarks/run_benchmark.py
+++ b/examples/benchmarks/run_benchmark.py
@@ -124,6 +124,8 @@ def main() -> None:
         case_ids=set(args.case_ids) if args.case_ids else None,
     )
     write_json(artifact, args.output)
+    if args.quick:
+        return
     unexpected = unexpected_mismatch_case_ids(artifact)
     if unexpected:
         raise SystemExit(

--- a/examples/benchmarks/run_benchmark.py
+++ b/examples/benchmarks/run_benchmark.py
@@ -91,21 +91,43 @@ def run_benchmark(
 
 
 def unexpected_mismatch_case_ids(artifact) -> tuple[str, ...]:
-    return tuple(
-        case["case_id"]
-        for case in artifact.get("cases", ())
-        if (case.get("assessment") or {}).get("status")
-        == DECLARATION_MISMATCH
-    )
+    return tuple(case_id for case_id, _checks in unexpected_mismatch_details(artifact))
+
+
+def unexpected_mismatch_details(artifact):
+    details = []
+    for case in artifact.get("cases", ()):
+        assessment = case.get("assessment") or {}
+        if assessment.get("status") != DECLARATION_MISMATCH:
+            continue
+        checks = tuple(
+            {
+                "field": check.get("field"),
+                "observed": check.get("observed"),
+                "expected": check.get("expected"),
+                "reason": check.get("reason"),
+            }
+            for check in assessment.get("checks", ())
+            if check.get("status") == DECLARATION_MISMATCH
+        )
+        details.append((case["case_id"], checks))
+    return tuple(details)
 
 
 def enforce_scientific_assessment(artifact) -> None:
-    unexpected = unexpected_mismatch_case_ids(artifact)
-    if unexpected:
-        raise SystemExit(
-            "Unexpected benchmark declaration mismatch: "
-            + ", ".join(unexpected)
-        )
+    details = unexpected_mismatch_details(artifact)
+    if not details:
+        return
+    lines = ["Unexpected benchmark declaration mismatch:"]
+    for case_id, checks in details:
+        lines.append(f"  {case_id}")
+        for check in checks:
+            lines.append(
+                "    "
+                f"{check['field']}: observed={check['observed']}, "
+                f"expected={check['expected']}, reason={check['reason']}"
+            )
+    raise SystemExit("\n".join(lines))
 
 
 def _parse_args() -> argparse.Namespace:

--- a/examples/benchmarks/run_benchmark.py
+++ b/examples/benchmarks/run_benchmark.py
@@ -99,6 +99,15 @@ def unexpected_mismatch_case_ids(artifact) -> tuple[str, ...]:
     )
 
 
+def enforce_scientific_assessment(artifact) -> None:
+    unexpected = unexpected_mismatch_case_ids(artifact)
+    if unexpected:
+        raise SystemExit(
+            "Unexpected benchmark declaration mismatch: "
+            + ", ".join(unexpected)
+        )
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", type=Path, required=True)
@@ -106,6 +115,11 @@ def _parse_args() -> argparse.Namespace:
         "--quick",
         action="store_true",
         help="Use N=64 for smoke testing; never use this for scientific baselines.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail the scientific acceptance command on unexpected declaration mismatches.",
     )
     parser.add_argument(
         "--case-id",
@@ -123,14 +137,8 @@ def main() -> None:
         case_ids=set(args.case_ids) if args.case_ids else None,
     )
     write_json(artifact, args.output)
-    if args.quick:
-        return
-    unexpected = unexpected_mismatch_case_ids(artifact)
-    if unexpected:
-        raise SystemExit(
-            "Unexpected benchmark declaration mismatch: "
-            + ", ".join(unexpected)
-        )
+    if args.strict and not args.quick:
+        enforce_scientific_assessment(artifact)
 
 
 if __name__ == "__main__":

--- a/examples/benchmarks/run_benchmark.py
+++ b/examples/benchmarks/run_benchmark.py
@@ -44,7 +44,7 @@ BENCHMARK_CASES = tuple(
 
 def run_benchmark(
     *,
-    n: int = 1000,
+    n: int = 300,
     seed: int = DEFAULT_SEED,
     case_ids: set[str] | None = None,
     serializer=None,
@@ -66,7 +66,6 @@ def run_benchmark(
             misda.evaluate(
                 mis_set,
                 metrics=("linear", "pareto"),
-                candidates=1,
             )
             case = serialize_benchmark_result(
                 declaration,
@@ -120,7 +119,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
     artifact = run_benchmark(
-        n=64 if args.quick else 1000,
+        n=64 if args.quick else 300,
         case_ids=set(args.case_ids) if args.case_ids else None,
     )
     write_json(artifact, args.output)

--- a/misda/benchmark.py
+++ b/misda/benchmark.py
@@ -506,7 +506,16 @@ class BenchmarkCase:
             structural_units=tuple(
                 tuple(unit) for unit in truth.get("blocks_expected", ())
             ),
-            graph_expectations={},
+            graph_expectations={
+                str(graph_name): {
+                    str(metric): int(value)
+                    for metric, value in expectations.items()
+                    if value is not None
+                }
+                for graph_name, expectations in (
+                    truth.get("graph_expectations") or {}
+                ).items()
+            },
             adversarial=bool(adversarial),
             notes=str(truth.get("notes", "")),
         )

--- a/misda/benchmark.py
+++ b/misda/benchmark.py
@@ -493,6 +493,7 @@ class BenchmarkCase:
     structural_dimension: Optional[int] = None
     structural_units: tuple[tuple[Any, ...], ...] = ()
     graph_expectations: Mapping[str, Mapping[str, int]] = field(default_factory=dict)
+    expected_mismatches: Mapping[str, str] = field(default_factory=dict)
     adversarial: bool = False
     notes: str = ""
 
@@ -516,6 +517,12 @@ class BenchmarkCase:
                     truth.get("graph_expectations") or {}
                 ).items()
             },
+            expected_mismatches={
+                str(field_name): str(reason)
+                for field_name, reason in (
+                    truth.get("expected_mismatches") or {}
+                ).items()
+            },
             adversarial=bool(adversarial),
             notes=str(truth.get("notes", "")),
         )
@@ -532,6 +539,16 @@ class BenchmarkCase:
             and len(flattened) == len(set(flattened)) == len(labels)
             and set(flattened) == set(labels)
         )
+
+    def _mismatch(self, field_name, default_reason):
+        if field_name in self.expected_mismatches:
+            return (
+                EXPECTED_DECLARATION_MISMATCH,
+                self.expected_mismatches[field_name],
+            )
+        if self.adversarial:
+            return EXPECTED_DECLARATION_MISMATCH, "KNOWN_ADVERSARIAL_CASE"
+        return DECLARATION_MISMATCH, default_reason
 
     def evaluate(self, result):
         if not isinstance(result, MISSet):
@@ -552,10 +569,10 @@ class BenchmarkCase:
             error = abs(int(observed) - int(expected))
             if error == 0:
                 status, reason = DECLARATION_MATCH, None
-            elif self.adversarial:
-                status, reason = EXPECTED_DECLARATION_MISMATCH, "KNOWN_ADVERSARIAL_CASE"
             else:
-                status, reason = DECLARATION_MISMATCH, "DECLARED_DIMENSION_MISMATCH"
+                status, reason = self._mismatch(
+                    name, "DECLARED_DIMENSION_MISMATCH"
+                )
             checks.append({
                 "field": name,
                 "status": status,
@@ -582,20 +599,15 @@ class BenchmarkCase:
                 if expected is None:
                     continue
                 observed = observed_summary.get(metric)
+                field_name = f"graphs.{graph_name}.{metric}"
                 if observed == expected:
                     graph_status, graph_reason = DECLARATION_MATCH, None
-                elif self.adversarial:
-                    graph_status, graph_reason = (
-                        EXPECTED_DECLARATION_MISMATCH,
-                        "KNOWN_ADVERSARIAL_CASE",
-                    )
                 else:
-                    graph_status, graph_reason = (
-                        DECLARATION_MISMATCH,
-                        "DECLARED_GRAPH_MISMATCH",
+                    graph_status, graph_reason = self._mismatch(
+                        field_name, "DECLARED_GRAPH_MISMATCH"
                     )
                 checks.append({
-                    "field": f"graphs.{graph_name}.{metric}",
+                    "field": field_name,
                     "status": graph_status,
                     "observed": observed,
                     "expected": expected,
@@ -620,15 +632,9 @@ class BenchmarkCase:
             )
             if unit_adequacy:
                 unit_status, unit_reason = DECLARATION_MATCH, None
-            elif self.adversarial:
-                unit_status, unit_reason = (
-                    EXPECTED_DECLARATION_MISMATCH,
-                    "KNOWN_ADVERSARIAL_CASE",
-                )
             else:
-                unit_status, unit_reason = (
-                    DECLARATION_MISMATCH,
-                    "DECLARED_UNIT_MISMATCH",
+                unit_status, unit_reason = self._mismatch(
+                    "selected_structural_units", "DECLARED_UNIT_MISMATCH"
                 )
             checks.append({
                 "field": "selected_structural_units",
@@ -658,7 +664,10 @@ class BenchmarkCase:
         return {
             "case_id": self.case_id,
             "status": status,
-            "known_adversarial": self.adversarial,
+            "known_adversarial": bool(
+                self.adversarial or self.expected_mismatches
+            ),
+            "expected_mismatches": dict(self.expected_mismatches),
             "dimension_errors": {
                 "latent": latent_error,
                 "structural": structural_error,

--- a/misda/benchmark.py
+++ b/misda/benchmark.py
@@ -274,6 +274,40 @@ def _support_reasons(result):
     return tuple(observed)
 
 
+def _evaluation_scope_text(result, family):
+    scope = result.evaluation_scope(family)
+    if scope is None:
+        return "not evaluated"
+    count, basis = scope
+    return f"{count}/{len(result)} candidates ({basis})"
+
+
+def _candidate_metric_values(result, family, attribute):
+    values = []
+    for candidate in result:
+        metrics = getattr(candidate, family, None)
+        if metrics is None:
+            continue
+        value = getattr(metrics, attribute, None)
+        if value is None:
+            continue
+        value = float(value)
+        if np.isfinite(value):
+            values.append(value)
+    return tuple(values)
+
+
+def _format_range(values):
+    if not values:
+        return "N/A"
+    values = tuple(float(value) for value in values)
+    return (
+        f"min={_format_metric(min(values))}, "
+        f"median={_format_metric(float(np.median(values)))}, "
+        f"max={_format_metric(max(values))}"
+    )
+
+
 @dataclass(frozen=True)
 class BenchmarkResult:
     result: MISSet
@@ -342,6 +376,81 @@ class BenchmarkResult:
         reasons = ", ".join(_support_reasons(self.result)) or "none"
         lines.append(f"  Support reason : {reasons}")
 
+        lines.append("Candidate evaluation evidence")
+        lines.append(
+            f"  Linear scope   : {_evaluation_scope_text(self.result, 'linear')}"
+        )
+        if preferred is not None and preferred.linear is not None:
+            linear = preferred.linear
+            lines.append(
+                "  Linear selected: "
+                f"mean_r2={_format_metric(linear.mean_r2)}, "
+                f"worst_r2={_format_metric(linear.worst_r2)}, "
+                f"mean_r2_se={_format_metric(linear.jackknife.mean_r2_se)}, "
+                f"worst_r2_se={_format_metric(linear.jackknife.worst_r2_se)}, "
+                f"jackknife_n={linear.jackknife.n_replicates}"
+            )
+            lines.append(
+                "  Linear across  : mean_r2 "
+                + _format_range(
+                    _candidate_metric_values(self.result, "linear", "mean_r2")
+                )
+            )
+            lines.append(
+                "                   worst_r2 "
+                + _format_range(
+                    _candidate_metric_values(self.result, "linear", "worst_r2")
+                )
+            )
+        else:
+            lines.append("  Linear selected: N/A")
+
+        lines.append(
+            f"  Pareto scope   : {_evaluation_scope_text(self.result, 'pareto')}"
+        )
+        if preferred is not None and preferred.pareto is not None:
+            pareto_observed = preferred.pareto
+            lines.append(
+                "  Pareto selected: "
+                f"retention={_format_metric(pareto_observed.retention)}, "
+                f"validity={_format_metric(pareto_observed.validity)}, "
+                f"jaccard={_format_metric(pareto_observed.jaccard)}, "
+                f"exact={_format_metric(pareto_observed.exact_preservation)}"
+            )
+            lines.append(
+                "  Pareto fronts  : "
+                f"full={pareto_observed.full_front_size}, "
+                f"reduced={pareto_observed.reduced_front_size}, "
+                f"intersection={pareto_observed.intersection_size}, "
+                f"union={pareto_observed.union_size}"
+            )
+            for attribute in ("retention", "validity", "jaccard"):
+                lines.append(
+                    f"  Pareto across  : {attribute} "
+                    + _format_range(
+                        _candidate_metric_values(
+                            self.result, "pareto", attribute
+                        )
+                    )
+                )
+        else:
+            lines.append("  Pareto selected: N/A")
+
+        nonlinear_scope = self.result.evaluation_scope("nonlinear")
+        if nonlinear_scope is not None:
+            lines.append(
+                f"  Nonlinear scope: {_evaluation_scope_text(self.result, 'nonlinear')}"
+            )
+            if preferred is not None and preferred.nonlinear is not None:
+                nonlinear = preferred.nonlinear
+                lines.append(
+                    "  Nonlinear sel. : "
+                    f"mean_r2={_format_metric(nonlinear.mean_r2)}, "
+                    f"worst_r2={_format_metric(nonlinear.worst_r2)}, "
+                    f"trees={nonlinear.n_trees}, "
+                    f"converged={_format_metric(nonlinear.converged)}"
+                )
+
         lines.append("Dimensional accuracy")
         lines.append(
             "  Latent         : "
@@ -376,7 +485,7 @@ class BenchmarkResult:
                 f"f1={_format_metric(self.structural_f1)}"
             )
 
-        lines.append("Pareto-front preservation")
+        lines.append("Pareto declaration agreement")
         if "pareto" in self.unavailable_reasons:
             lines.append("  N/A — " + self.unavailable_reasons["pareto"])
         else:

--- a/misda/benchmark.py
+++ b/misda/benchmark.py
@@ -664,11 +664,14 @@ class BenchmarkCase:
             and set(flattened) == set(labels)
         )
 
-    def _mismatch(self, field_name, default_reason):
-        if field_name in self.expected_mismatches:
+    def _mismatch(self, field_name, default_reason, observed_support_reasons):
+        expected_reason = self.expected_mismatches.get(field_name)
+        if expected_reason is not None:
+            if expected_reason in observed_support_reasons:
+                return EXPECTED_DECLARATION_MISMATCH, expected_reason
             return (
-                EXPECTED_DECLARATION_MISMATCH,
-                self.expected_mismatches[field_name],
+                DECLARATION_MISMATCH,
+                f"{default_reason}; EXPECTED_DIAGNOSTIC_NOT_OBSERVED:{expected_reason}",
             )
         if self.adversarial:
             return EXPECTED_DECLARATION_MISMATCH, "KNOWN_ADVERSARIAL_CASE"
@@ -679,6 +682,7 @@ class BenchmarkCase:
             raise TypeError("result must be an MISSet returned by discover().")
         analysis = result.analysis
         checks = []
+        observed_support_reasons = set(_support_reasons(result))
 
         def dimension_check(name, observed, expected):
             if expected is None:
@@ -695,7 +699,9 @@ class BenchmarkCase:
                 status, reason = DECLARATION_MATCH, None
             else:
                 status, reason = self._mismatch(
-                    name, "DECLARED_DIMENSION_MISMATCH"
+                    name,
+                    "DECLARED_DIMENSION_MISMATCH",
+                    observed_support_reasons,
                 )
             checks.append({
                 "field": name,
@@ -728,7 +734,9 @@ class BenchmarkCase:
                     graph_status, graph_reason = DECLARATION_MATCH, None
                 else:
                     graph_status, graph_reason = self._mismatch(
-                        field_name, "DECLARED_GRAPH_MISMATCH"
+                        field_name,
+                        "DECLARED_GRAPH_MISMATCH",
+                        observed_support_reasons,
                     )
                 checks.append({
                     "field": field_name,
@@ -758,7 +766,9 @@ class BenchmarkCase:
                 unit_status, unit_reason = DECLARATION_MATCH, None
             else:
                 unit_status, unit_reason = self._mismatch(
-                    "selected_structural_units", "DECLARED_UNIT_MISMATCH"
+                    "selected_structural_units",
+                    "DECLARED_UNIT_MISMATCH",
+                    observed_support_reasons,
                 )
             checks.append({
                 "field": "selected_structural_units",
@@ -792,6 +802,7 @@ class BenchmarkCase:
                 self.adversarial or self.expected_mismatches
             ),
             "expected_mismatches": dict(self.expected_mismatches),
+            "observed_support_reasons": tuple(sorted(observed_support_reasons)),
             "dimension_errors": {
                 "latent": latent_error,
                 "structural": structural_error,

--- a/misda/benchmark.py
+++ b/misda/benchmark.py
@@ -342,6 +342,7 @@ class BenchmarkResult:
     pareto_lost: Optional[int]
     pareto_spurious: Optional[int]
     unavailable_reasons: Mapping[str, str]
+    assessment: Mapping[str, Any]
 
     def report(self):
         analysis = self.result.analysis
@@ -450,6 +451,17 @@ class BenchmarkResult:
                     f"trees={nonlinear.n_trees}, "
                     f"converged={_format_metric(nonlinear.converged)}"
                 )
+
+        lines.append("Declaration assessment")
+        lines.append(f"  Status         : {self.assessment['status']}")
+        for check in self.assessment.get("checks", ()):
+            reason = check.get("reason") or "none"
+            lines.append(
+                "  "
+                f"{check['field']}: status={check['status']}, "
+                f"observed={check.get('observed')}, "
+                f"expected={check.get('expected')}, reason={reason}"
+            )
 
         lines.append("Dimensional accuracy")
         lines.append(
@@ -566,6 +578,9 @@ def benchmark(result, truth):
     if structural_expected is None:
         unavailable["structural_dimension"] = "structural_expected was not declared"
 
+    case_id = _truth_text(truth, "case_id") or _truth_text(truth, "name") or "benchmark"
+    assessment = BenchmarkCase.from_truth(case_id, truth).evaluate(result)
+
     return BenchmarkResult(
         result=result,
         truth=truth,
@@ -588,6 +603,7 @@ def benchmark(result, truth):
         structural_relative_error=structural_dimension[1],
         structural_dimension_exact=structural_dimension[2],
         unavailable_reasons=unavailable,
+        assessment=assessment,
         **structural,
         **pareto,
     )
@@ -609,7 +625,7 @@ class BenchmarkCase:
     def from_truth(cls, case_id, truth, *, adversarial=False):
         return cls(
             case_id=str(case_id),
-            name=str(truth["name"]),
+            name=str(truth.get("name") or case_id),
             latent_dimension=truth.get("latent_expected"),
             structural_dimension=truth.get("structural_expected"),
             structural_units=tuple(

--- a/misda/benchmark.py
+++ b/misda/benchmark.py
@@ -115,10 +115,9 @@ def _truth_blocks(truth):
 
 
 def _truth_components(truth):
-    components = truth.get("components_expected")
-    if components is None:
-        return _truth_blocks(truth)
-    return _normalize_label_blocks(components, "components_expected")
+    return _normalize_label_blocks(
+        truth.get("components_expected"), "components_expected"
+    )
 
 
 def _truth_pareto_indices(truth):
@@ -424,7 +423,7 @@ def benchmark(result, truth):
             "structural_f1": None,
             "structural_partition_exact": None,
         }
-        unavailable["structural"] = "blocks_expected was not declared"
+        unavailable["structural"] = "components_expected was not declared"
     else:
         structural = _structural_metrics(found_blocks, components_expected)
 

--- a/misda/benchmark.py
+++ b/misda/benchmark.py
@@ -95,20 +95,30 @@ def _truth_dimension(truth, field_name):
     return value
 
 
-def _truth_blocks(truth):
-    blocks = truth.get("blocks_expected")
-    if blocks is None:
+def _normalize_label_blocks(value, field_name):
+    if value is None:
         return None
     try:
-        normalized = tuple(tuple(block) for block in blocks)
+        normalized = tuple(tuple(block) for block in value)
         for block in normalized:
             for label in block:
                 hash(label)
     except (TypeError, ValueError) as exc:
         raise TypeError(
-            "truth['blocks_expected'] must be a sequence of label sequences."
+            f"truth[{field_name!r}] must be a sequence of label sequences."
         ) from exc
     return normalized
+
+
+def _truth_blocks(truth):
+    return _normalize_label_blocks(truth.get("blocks_expected"), "blocks_expected")
+
+
+def _truth_components(truth):
+    components = truth.get("components_expected")
+    if components is None:
+        return _truth_blocks(truth)
+    return _normalize_label_blocks(components, "components_expected")
 
 
 def _truth_pareto_indices(truth):
@@ -277,6 +287,7 @@ class BenchmarkResult:
     latent_expected: Optional[int]
     structural_expected: Optional[int]
     blocks_expected: Optional[tuple]
+    components_expected: Optional[tuple]
     pareto_expected: Optional[tuple]
     found_blocks: tuple
     selected_dimension: Optional[int]
@@ -310,6 +321,7 @@ class BenchmarkResult:
         lines.append(f"  Intuition      : {self.intuition or 'N/A'}")
         lines.append(f"  Expected graph : {self.graph_expected or 'N/A'}")
         lines.append(f"  Expected blocks: {_format_blocks(self.blocks_expected)}")
+        lines.append(f"  Expected comps.: {_format_blocks(self.components_expected)}")
         if self.notes:
             lines.append(f"  Notes          : {self.notes}")
 
@@ -326,7 +338,7 @@ class BenchmarkResult:
             + (_format_blocks((preferred.objectives,)) if preferred else "N/A")
         )
         lines.append(f"  Ranking policy : {ranking.policy}")
-        lines.append(f"  Found blocks   : {_format_blocks(self.found_blocks)}")
+        lines.append(f"  Found comps.   : {_format_blocks(self.found_blocks)}")
         lines.append(f"  Dim. support   : {self.result.support.status}")
         reasons = ", ".join(_support_reasons(self.result)) or "none"
         lines.append(f"  Support reason : {reasons}")
@@ -349,7 +361,7 @@ class BenchmarkResult:
             f"exact={_format_metric(self.structural_dimension_exact)}"
         )
 
-        lines.append("Structural reconstruction")
+        lines.append("Structural component reconstruction")
         if "structural" in self.unavailable_reasons:
             lines.append("  N/A — " + self.unavailable_reasons["structural"])
         else:
@@ -393,6 +405,7 @@ def benchmark(result, truth):
     latent_expected = _truth_dimension(truth, "latent_expected")
     structural_expected = _truth_dimension(truth, "structural_expected")
     blocks_expected = _truth_blocks(truth)
+    components_expected = _truth_components(truth)
     pareto_expected = _truth_pareto_indices(truth)
     found_blocks = _found_structural_blocks(result)
     preferred = result.structural_ranking.selected
@@ -403,7 +416,7 @@ def benchmark(result, truth):
     )
     unavailable = {}
 
-    if blocks_expected is None:
+    if components_expected is None:
         structural = {
             "structural_jaccard": None,
             "structural_precision": None,
@@ -413,7 +426,7 @@ def benchmark(result, truth):
         }
         unavailable["structural"] = "blocks_expected was not declared"
     else:
-        structural = _structural_metrics(found_blocks, blocks_expected)
+        structural = _structural_metrics(found_blocks, components_expected)
 
     if pareto_expected is None:
         pareto = {
@@ -456,6 +469,7 @@ def benchmark(result, truth):
         latent_expected=latent_expected,
         structural_expected=structural_expected,
         blocks_expected=blocks_expected,
+        components_expected=components_expected,
         pareto_expected=pareto_expected,
         found_blocks=found_blocks,
         selected_dimension=result.structural_ranking.selected_dimension,

--- a/misda/benchmarks/cases.py
+++ b/misda/benchmarks/cases.py
@@ -14,6 +14,7 @@ def _truth(
     graph_expected="",
     pareto_expected=None,
     notes="",
+    graph_expectations=None,
 ):
     return {
         "name": name,
@@ -37,6 +38,7 @@ def _truth(
         "feature": feature,
         "intuition": intuition,
         "graph_expected": graph_expected,
+        "graph_expectations": dict(graph_expectations or {}),
         "notes": notes,
     }
 
@@ -54,6 +56,10 @@ def make_case1_independence(N=1000, M=20, seed=123):
         feature="All 20 objectives are mutually independent i.i.d. Gaussian noise variables.",
         intuition="20 completely unrelated random sensors; knowing one tells you nothing about any other. MISDA should keep all 20.",
         graph_expected="20 isolated nodes (0 edges, 20 connected components)",
+        graph_expectations={
+            "structural": {"edges": 0, "components": 20},
+            "dependence": {"edges": 0, "components": 20},
+        },
     )
     return df, truth
 
@@ -73,6 +79,10 @@ def make_case2_total_redundancy(N=1000, M=20, seed=123):
         feature="All 20 objectives are noisy linear copies of a single 1D latent factor.",
         intuition="20 identical thermometers measuring the exact same room temperature with minor noise. MISDA should keep just 1.",
         graph_expected="1 fully connected graph (K_20, 190 edges, 1 connected component)",
+        graph_expectations={
+            "structural": {"edges": 190, "components": 1},
+            "dependence": {"edges": 190, "components": 1},
+        },
     )
     return df, truth
 
@@ -102,6 +112,10 @@ def make_case3_block_structure(N=1000, M=20, seed=123):
         feature="4 independent latent factors; each factor generates a cluster of 5 redundant objectives.",
         intuition="4 physical properties (e.g., Temp, Pressure, Humidity, Speed), each measured by 5 duplicate sensors. MISDA should reduce 20 sensors to 4.",
         graph_expected="4 disjoint complete subgraphs of 5 nodes each (4 x K_5, 40 total edges)",
+        graph_expectations={
+            "structural": {"edges": 40, "components": 4},
+            "dependence": {"edges": 40, "components": 4},
+        },
     )
     return df, truth
 
@@ -128,6 +142,10 @@ def make_case4_two_big_blocks(N=1000, M=20, seed=123):
         feature="2 independent latent factors; each factor generates a cluster of 10 redundant objectives.",
         intuition="Measuring 2 goals (e.g., Cost and Weight), but using 10 duplicate formulas for Cost and 10 for Weight. MISDA should reduce 20 formulas to 2.",
         graph_expected="2 disjoint complete subgraphs of 10 nodes each (2 x K_10, 90 total edges)",
+        graph_expectations={
+            "structural": {"edges": 90, "components": 2},
+            "dependence": {"edges": 90, "components": 2},
+        },
     )
     return df, truth
 
@@ -148,6 +166,7 @@ def make_case5_chain_structure(N=1000, M=20, seed=123):
         feature="Markovian random walk chain where correlation decays smoothly with index distance.",
         intuition="A chain of 20 dominoes: adjacent dominoes are strongly linked, but the 1st and 20th are far apart. Tests gradual, step-by-step continuous dependency.",
         graph_expected="1 connected chain/band graph (adjacent node edges, 1 connected component)",
+        graph_expectations={"structural": {"components": 1}},
     )
     return df, truth
 
@@ -179,6 +198,10 @@ def make_case6_mixed_structure(N=1000, M=20, seed=123):
         feature="Heterogeneous structure: 10 independent noise objectives (f1..f10) and 2 redundant blocks of 5.",
         intuition="10 random independent variables mixed with 2 redundant groups of 5 sensors each. MISDA should keep 10 + 2 = 12 objectives.",
         graph_expected="10 isolated nodes and 2 disjoint complete subgraphs of 5 nodes each (10 x K_1 + 2 x K_5)",
+        graph_expectations={
+            "structural": {"edges": 20, "components": 12},
+            "dependence": {"edges": 20, "components": 12},
+        },
     )
     return df, truth
 
@@ -209,6 +232,10 @@ def make_case7_pure_conflict_groups(
         feature="Two groups (+x and -x) with internal redundancy and strong structural conflict (anti-correlation).",
         intuition="10 sensors measuring Car Speed (+x) and 10 measuring Remaining Travel Time (-x). Speed and Time conflict, but both are essential! MISDA must keep 1 of each.",
         graph_expected="2 disjoint complete subgraphs of 10 nodes each (2 x K_10, 90 total edges, 2 connected components)",
+        graph_expectations={
+            "structural": {"edges": 90, "components": 2},
+            "dependence": {"edges": 190, "components": 1},
+        },
     )
     return Y, truth
 

--- a/misda/benchmarks/cases.py
+++ b/misda/benchmarks/cases.py
@@ -15,6 +15,7 @@ def _truth(
     pareto_expected=None,
     notes="",
     graph_expectations=None,
+    expected_mismatches=None,
 ):
     return {
         "name": name,
@@ -39,6 +40,7 @@ def _truth(
         "intuition": intuition,
         "graph_expected": graph_expected,
         "graph_expectations": dict(graph_expectations or {}),
+        "expected_mismatches": dict(expected_mismatches or {}),
         "notes": notes,
     }
 
@@ -167,6 +169,10 @@ def make_case5_chain_structure(N=1000, M=20, seed=123):
         intuition="A chain of 20 dominoes: adjacent dominoes are strongly linked, but the 1st and 20th are far apart. Tests gradual, step-by-step continuous dependency.",
         graph_expected="1 connected chain/band graph (adjacent node edges, 1 connected component)",
         graph_expectations={"structural": {"components": 1}},
+        expected_mismatches={
+            "latent_dimension": "TRANSITIVE_CHAINING",
+            "structural_dimension": "TRANSITIVE_CHAINING",
+        },
     )
     return df, truth
 

--- a/misda/benchmarks/cases.py
+++ b/misda/benchmarks/cases.py
@@ -28,6 +28,7 @@ def _truth(
             else None
         ),
         "blocks_expected": blocks_expected,
+        "components_expected": blocks_expected,
         "pareto_expected": (
             None
             if pareto_expected is None

--- a/misda/benchmarks/mop.py
+++ b/misda/benchmarks/mop.py
@@ -16,6 +16,7 @@ def _mop_truth(
     pareto_expected=None,
     components_expected=None,
     graph_expectations=None,
+    expected_mismatches=None,
 ):
     return {
         "name": name,
@@ -35,6 +36,7 @@ def _mop_truth(
         "intuition": intuition,
         "graph_expected": graph_expected,
         "graph_expectations": dict(graph_expectations or {}),
+        "expected_mismatches": dict(expected_mismatches or {}),
     }
 
 
@@ -342,6 +344,11 @@ def mopF_regime_switching(N=1000, seed=123, sharpness=20.0, noise=0.0):
         intuition="System switching: indicators change behavior depending on whether the system operates in High-Power or Low-Power mode. Tests MISDA under shifting states.",
         graph_expected="1 connected graph with 2 dense interconnected clusters (10 on mixture L, 10 on b)",
         graph_expectations={"structural": {"components": 1}},
+        expected_mismatches={
+            "latent_dimension": "HIDDEN_SPECTRAL_STRUCTURE",
+            "structural_dimension": "HIDDEN_SPECTRAL_STRUCTURE",
+            "selected_structural_units": "HIDDEN_SPECTRAL_STRUCTURE",
+        },
     )
     return _mop_df(Y), truth
 

--- a/misda/benchmarks/mop.py
+++ b/misda/benchmarks/mop.py
@@ -14,12 +14,16 @@ def _mop_truth(
     intuition="",
     graph_expected="",
     pareto_expected=None,
+    components_expected=None,
 ):
     return {
         "name": name,
         "latent_expected": int(latent_expected),
         "structural_expected": int(structural_expected),
         "blocks_expected": blocks_expected,
+        "components_expected": (
+            blocks_expected if components_expected is None else components_expected
+        ),
         "pareto_expected": (
             None
             if pareto_expected is None
@@ -140,6 +144,7 @@ def mopB_tradeoff_with_redundancies(N=1000, seed=123, noise=0.02):
         latent_expected=2,
         structural_expected=2,
         blocks_expected=[_mk_block_names(1, 7), _mk_block_names(8, 7), _mk_block_names(15, 6)],
+        components_expected=[_mk_block_names(1, 20)],
         notes="Three families (cost/consumption/performance) with internal redundancies; effective tends to ~2.",
         feature="Three functional engineering families (7 cost, 7 consumption, 6 performance) driven by 2 decision variables.",
         intuition="An engineering problem with 3 main goals: Cost, Energy, and Performance, each measured in multiple redundant ways. MISDA should shrink 20 to ~2-3 core trade-offs.",
@@ -267,6 +272,7 @@ def mopE_partial_redundancy_noisy(N=1000, seed=123, noise=0.05):
         latent_expected=2,
         structural_expected=2,
         blocks_expected=[_mk_block_names(1,10), _mk_block_names(11,4), _mk_block_names(15,6)],
+        components_expected=[_mk_block_names(1, 20)],
         notes="Trio/quartet of 'a' extended to 10 redundants; 'b' (4); and 6 compounds around s=a+b.",
         feature="Partial redundancy across 2 latent drivers (a,b): 10 objectives on a, 4 on b, and 6 compounds on s=a+b.",
         intuition="Overlapping signals: some indicators monitor Engine A, some monitor Engine B, and some monitor both combined (A+B). Tests if MISDA untangles blended signals.",
@@ -320,6 +326,7 @@ def mopF_regime_switching(N=1000, seed=123, sharpness=20.0, noise=0.0):
         latent_expected=2,
         structural_expected=2,
         blocks_expected=[_mk_block_names(1,10), _mk_block_names(11,10)],
+        components_expected=[_mk_block_names(1, 20)],
         notes="10 objectives redundant around L (mixture by regime) + 10 redundant around b; global correlation can be misleading.",
         feature="Non-linear regime-switching mixture: 10 objectives on regime-dependent mixture L(a,b) and 10 on b.",
         intuition="System switching: indicators change behavior depending on whether the system operates in High-Power or Low-Power mode. Tests MISDA under shifting states.",

--- a/misda/benchmarks/mop.py
+++ b/misda/benchmarks/mop.py
@@ -15,6 +15,7 @@ def _mop_truth(
     graph_expected="",
     pareto_expected=None,
     components_expected=None,
+    graph_expectations=None,
 ):
     return {
         "name": name,
@@ -33,6 +34,7 @@ def _mop_truth(
         "feature": feature,
         "intuition": intuition,
         "graph_expected": graph_expected,
+        "graph_expectations": dict(graph_expectations or {}),
     }
 
 
@@ -88,6 +90,7 @@ def mopA_monotonic_redundancy(N=1000, seed=123, noise=0.0):
         feature="20 non-linear monotonic transformations driven by a single 1D decision variable x.",
         intuition="20 different formulas (squares, roots, logs) calculated from a single input x. Since all move in sync, MISDA should collapse all 20 to 1.",
         graph_expected="1 fully connected graph (K_20, 190 edges, 1 connected component)",
+        graph_expectations={"structural": {"components": 1}},
     )
     return _mop_df(Y), truth
 
@@ -149,6 +152,7 @@ def mopB_tradeoff_with_redundancies(N=1000, seed=123, noise=0.02):
         feature="Three functional engineering families (7 cost, 7 consumption, 6 performance) driven by 2 decision variables.",
         intuition="An engineering problem with 3 main goals: Cost, Energy, and Performance, each measured in multiple redundant ways. MISDA should shrink 20 to ~2-3 core trade-offs.",
         graph_expected="1 connected graph with 3 dense functional clusters (1 connected component, effective dim ~2)",
+        graph_expectations={"structural": {"components": 1}},
     )
     return _mop_df(Y), truth
 
@@ -176,6 +180,7 @@ def mopC_latent_blocks_4x5(N=1000, seed=123, noise=0.02):
         feature="4 independent decision factors; each factor generates a block of 5 non-linearly transformed objectives.",
         intuition="4 control dials, where turning each dial affects 5 non-linear indicators. MISDA should extract 4 independent representatives (1 per dial).",
         graph_expected="4 disjoint dense subgraphs of 5 nodes each (4 x K_5, 4 connected components)",
+        graph_expectations={"structural": {"components": 4}},
     )
     return _mop_df(Y), truth
 
@@ -223,6 +228,10 @@ def mopD_pure_conflict_groups(N=1000, seed=123, noise=0.0):
         feature="Two antagonistic non-linear objective families (+x vs 1-x) with internal redundancy and trade-off conflict.",
         intuition="10 indicators measuring Benefit (+x) vs 10 measuring Risk (1-x). Benefit and Risk directly conflict. MISDA must preserve 1 Benefit and 1 Risk indicator.",
         graph_expected="2 disjoint complete subgraphs of 10 nodes each (2 x K_10, 90 total edges, 2 connected components)",
+        graph_expectations={
+            "structural": {"components": 2},
+            "dependence": {"components": 1},
+        },
     )
     return _mop_df(Y), truth
 
@@ -277,6 +286,7 @@ def mopE_partial_redundancy_noisy(N=1000, seed=123, noise=0.05):
         feature="Partial redundancy across 2 latent drivers (a,b): 10 objectives on a, 4 on b, and 6 compounds on s=a+b.",
         intuition="Overlapping signals: some indicators monitor Engine A, some monitor Engine B, and some monitor both combined (A+B). Tests if MISDA untangles blended signals.",
         graph_expected="1 connected graph with 3 dense overlapping clusters (Subfamily A: 10, B: 4, C: 6)",
+        graph_expectations={"structural": {"components": 1}},
     )
     return _mop_df(Y), truth
 
@@ -331,6 +341,7 @@ def mopF_regime_switching(N=1000, seed=123, sharpness=20.0, noise=0.0):
         feature="Non-linear regime-switching mixture: 10 objectives on regime-dependent mixture L(a,b) and 10 on b.",
         intuition="System switching: indicators change behavior depending on whether the system operates in High-Power or Low-Power mode. Tests MISDA under shifting states.",
         graph_expected="1 connected graph with 2 dense interconnected clusters (10 on mixture L, 10 on b)",
+        graph_expectations={"structural": {"components": 1}},
     )
     return _mop_df(Y), truth
 

--- a/tests/test_benchmark_clis.py
+++ b/tests/test_benchmark_clis.py
@@ -1,5 +1,6 @@
 """Smoke tests for executable benchmark front ends under the new public API."""
 
+import inspect
 import json
 import importlib
 import subprocess
@@ -199,3 +200,21 @@ def test_cli_never_passes_case_declarations_into_discover(monkeypatch):
             "seed": 123,
         }
     ]
+
+
+def test_benchmark_runner_matches_notebook_reference_scope(monkeypatch):
+    module = importlib.import_module("examples.benchmarks.run_benchmark")
+    assert inspect.signature(module.run_benchmark).parameters["n"].default == 300
+
+    original = module.misda.evaluate
+    observed_kwargs = []
+
+    def capture(result, **kwargs):
+        observed_kwargs.append(dict(kwargs))
+        return original(result, **kwargs)
+
+    monkeypatch.setattr(module.misda, "evaluate", capture)
+    artifact = module.run_benchmark(n=32, case_ids={"case_02"})
+
+    assert len(artifact["cases"]) == 1
+    assert observed_kwargs == [{"metrics": ("linear", "pareto")}]

--- a/tests/test_benchmark_component_declarations.py
+++ b/tests/test_benchmark_component_declarations.py
@@ -1,0 +1,42 @@
+"""Regression tests for benchmark component declarations."""
+
+from misda.benchmark import _structural_metrics, _truth_components
+from misda.benchmarks.cases import make_case3_block_structure
+from misda.benchmarks.mop import mopB_tradeoff_with_redundancies
+
+
+def test_component_truth_is_distinct_from_generating_blocks_when_needed():
+    _frame, truth = mopB_tradeoff_with_redundancies(N=64, seed=123)
+
+    assert [len(block) for block in truth["blocks_expected"]] == [7, 7, 6]
+    assert [len(block) for block in truth["components_expected"]] == [20]
+    assert _truth_components(truth) == tuple(
+        tuple(block) for block in truth["components_expected"]
+    )
+
+    found_components = (tuple(f"f{i}" for i in range(1, 21)),)
+    component_metrics = _structural_metrics(
+        found_components,
+        truth["components_expected"],
+    )
+    block_metrics = _structural_metrics(
+        found_components,
+        truth["blocks_expected"],
+    )
+
+    assert component_metrics["structural_partition_exact"]
+    assert component_metrics["structural_jaccard"] == 1.0
+    assert not block_metrics["structural_partition_exact"]
+    assert block_metrics["structural_jaccard"] < 1.0
+
+
+def test_canonical_block_cases_keep_component_partition_when_they_coincide():
+    _frame, truth = make_case3_block_structure(N=64, seed=123)
+
+    assert truth["components_expected"] == truth["blocks_expected"]
+    metrics = _structural_metrics(
+        truth["components_expected"],
+        truth["blocks_expected"],
+    )
+    assert metrics["structural_partition_exact"]
+    assert metrics["structural_jaccard"] == 1.0

--- a/tests/test_benchmark_expected_mismatches.py
+++ b/tests/test_benchmark_expected_mismatches.py
@@ -1,5 +1,7 @@
 """Regression tests for expected versus unexpected benchmark mismatches."""
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -15,6 +17,7 @@ from misda.benchmark import (
     EXPECTED_DECLARATION_MISMATCH,
 )
 from misda.benchmarks.cases import make_case5_chain_structure
+from misda.benchmarks.mop import mopF_regime_switching
 
 
 def _two_group_result():
@@ -23,8 +26,16 @@ def _two_group_result():
     return misda.discover(data, seed=19, name="two groups")
 
 
+def _set_support_reasons(result, *reasons):
+    result.support = SimpleNamespace(
+        status="UNSUPPORTED" if reasons else "SUPPORTED",
+        results=(SimpleNamespace(reasons=tuple(reasons)),),
+    )
+
+
 def test_expected_mismatches_are_field_specific_not_blanket_adversarial():
     result = _two_group_result()
+    _set_support_reasons(result, "TRANSITIVE_CHAINING")
     case = BenchmarkCase.from_truth(
         "x",
         {
@@ -48,6 +59,43 @@ def test_expected_mismatches_are_field_specific_not_blanket_adversarial():
     assert checks["structural_dimension"]["status"] == EXPECTED_DECLARATION_MISMATCH
     assert checks["graphs.structural.components"]["status"] == DECLARATION_MISMATCH
     assert assessment["status"] == DECLARATION_MISMATCH
+    assert assessment["observed_support_reasons"] == ("TRANSITIVE_CHAINING",)
+
+
+def test_expected_mismatch_requires_matching_observed_diagnostic():
+    result = _two_group_result()
+    _set_support_reasons(result)
+    case = BenchmarkCase.from_truth(
+        "x",
+        {
+            "name": "diagnostic-gated mismatch",
+            "latent_expected": 4,
+            "expected_mismatches": {
+                "latent_dimension": "TRANSITIVE_CHAINING",
+            },
+        },
+    )
+
+    assessment = case.evaluate(result)
+    latent = next(
+        check for check in assessment["checks"]
+        if check["field"] == "latent_dimension"
+    )
+    assert latent["status"] == DECLARATION_MISMATCH
+    assert latent["reason"] == (
+        "DECLARED_DIMENSION_MISMATCH; "
+        "EXPECTED_DIAGNOSTIC_NOT_OBSERVED:TRANSITIVE_CHAINING"
+    )
+    assert assessment["observed_support_reasons"] == ()
+
+    _set_support_reasons(result, "TRANSITIVE_CHAINING")
+    assessment = case.evaluate(result)
+    latent = next(
+        check for check in assessment["checks"]
+        if check["field"] == "latent_dimension"
+    )
+    assert latent["status"] == EXPECTED_DECLARATION_MISMATCH
+    assert latent["reason"] == "TRANSITIVE_CHAINING"
 
 
 def test_case5_declares_only_dimensional_chaining_mismatches():
@@ -56,6 +104,16 @@ def test_case5_declares_only_dimensional_chaining_mismatches():
     assert truth["expected_mismatches"] == {
         "latent_dimension": "TRANSITIVE_CHAINING",
         "structural_dimension": "TRANSITIVE_CHAINING",
+    }
+
+
+def test_mopf_declares_only_spectral_structure_mismatches():
+    _frame, truth = mopF_regime_switching(N=64, seed=123)
+
+    assert truth["expected_mismatches"] == {
+        "latent_dimension": "HIDDEN_SPECTRAL_STRUCTURE",
+        "structural_dimension": "HIDDEN_SPECTRAL_STRUCTURE",
+        "selected_structural_units": "HIDDEN_SPECTRAL_STRUCTURE",
     }
 
 

--- a/tests/test_benchmark_expected_mismatches.py
+++ b/tests/test_benchmark_expected_mismatches.py
@@ -7,6 +7,7 @@ import misda
 from examples.benchmarks.run_benchmark import (
     enforce_scientific_assessment,
     unexpected_mismatch_case_ids,
+    unexpected_mismatch_details,
 )
 from misda.benchmark import (
     BenchmarkCase,
@@ -74,7 +75,32 @@ def test_strict_gate_rejects_only_unexpected_declaration_mismatches():
     assert unexpected_mismatch_case_ids(artifact) == ()
     enforce_scientific_assessment(artifact)
 
-    artifact["cases"][1]["assessment"]["status"] = DECLARATION_MISMATCH
+    artifact["cases"][1]["assessment"] = {
+        "status": DECLARATION_MISMATCH,
+        "checks": [
+            {
+                "field": "structural_dimension",
+                "status": DECLARATION_MISMATCH,
+                "observed": 3,
+                "expected": 4,
+                "reason": "DECLARED_DIMENSION_MISMATCH",
+            }
+        ],
+    }
     assert unexpected_mismatch_case_ids(artifact) == ("case_03",)
-    with pytest.raises(SystemExit, match="case_03"):
+    details = unexpected_mismatch_details(artifact)
+    assert details == (
+        (
+            "case_03",
+            (
+                {
+                    "field": "structural_dimension",
+                    "observed": 3,
+                    "expected": 4,
+                    "reason": "DECLARED_DIMENSION_MISMATCH",
+                },
+            ),
+        ),
+    )
+    with pytest.raises(SystemExit, match="structural_dimension: observed=3, expected=4"):
         enforce_scientific_assessment(artifact)

--- a/tests/test_benchmark_expected_mismatches.py
+++ b/tests/test_benchmark_expected_mismatches.py
@@ -1,9 +1,13 @@
 """Regression tests for expected versus unexpected benchmark mismatches."""
 
 import numpy as np
+import pytest
 
 import misda
-from examples.benchmarks.run_benchmark import unexpected_mismatch_case_ids
+from examples.benchmarks.run_benchmark import (
+    enforce_scientific_assessment,
+    unexpected_mismatch_case_ids,
+)
 from misda.benchmark import (
     BenchmarkCase,
     DECLARATION_MISMATCH,
@@ -68,6 +72,9 @@ def test_strict_gate_rejects_only_unexpected_declaration_mismatches():
         ]
     }
     assert unexpected_mismatch_case_ids(artifact) == ()
+    enforce_scientific_assessment(artifact)
 
     artifact["cases"][1]["assessment"]["status"] = DECLARATION_MISMATCH
     assert unexpected_mismatch_case_ids(artifact) == ("case_03",)
+    with pytest.raises(SystemExit, match="case_03"):
+        enforce_scientific_assessment(artifact)

--- a/tests/test_benchmark_expected_mismatches.py
+++ b/tests/test_benchmark_expected_mismatches.py
@@ -1,0 +1,73 @@
+"""Regression tests for expected versus unexpected benchmark mismatches."""
+
+import numpy as np
+
+import misda
+from examples.benchmarks.run_benchmark import unexpected_mismatch_case_ids
+from misda.benchmark import (
+    BenchmarkCase,
+    DECLARATION_MISMATCH,
+    EXPECTED_DECLARATION_MISMATCH,
+)
+from misda.benchmarks.cases import make_case5_chain_structure
+
+
+def _two_group_result():
+    x = np.array([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0])
+    data = np.column_stack([x, 2.0 * x, -x, -2.0 * x])
+    return misda.discover(data, seed=19, name="two groups")
+
+
+def test_expected_mismatches_are_field_specific_not_blanket_adversarial():
+    result = _two_group_result()
+    case = BenchmarkCase.from_truth(
+        "x",
+        {
+            "name": "field-specific mismatch",
+            "latent_expected": 4,
+            "structural_expected": 4,
+            "blocks_expected": [["f1", "f2"], ["f3", "f4"]],
+            "graph_expectations": {"structural": {"components": 1}},
+            "expected_mismatches": {
+                "latent_dimension": "TRANSITIVE_CHAINING",
+                "structural_dimension": "TRANSITIVE_CHAINING",
+            },
+        },
+    )
+
+    assessment = case.evaluate(result)
+    checks = {check["field"]: check for check in assessment["checks"]}
+
+    assert checks["latent_dimension"]["status"] == EXPECTED_DECLARATION_MISMATCH
+    assert checks["latent_dimension"]["reason"] == "TRANSITIVE_CHAINING"
+    assert checks["structural_dimension"]["status"] == EXPECTED_DECLARATION_MISMATCH
+    assert checks["graphs.structural.components"]["status"] == DECLARATION_MISMATCH
+    assert assessment["status"] == DECLARATION_MISMATCH
+
+
+def test_case5_declares_only_dimensional_chaining_mismatches():
+    _frame, truth = make_case5_chain_structure(N=64, seed=123)
+
+    assert truth["expected_mismatches"] == {
+        "latent_dimension": "TRANSITIVE_CHAINING",
+        "structural_dimension": "TRANSITIVE_CHAINING",
+    }
+
+
+def test_strict_gate_rejects_only_unexpected_declaration_mismatches():
+    artifact = {
+        "cases": [
+            {
+                "case_id": "case_05",
+                "assessment": {"status": EXPECTED_DECLARATION_MISMATCH},
+            },
+            {
+                "case_id": "case_03",
+                "assessment": {"status": "DECLARATION_MATCH"},
+            },
+        ]
+    }
+    assert unexpected_mismatch_case_ids(artifact) == ()
+
+    artifact["cases"][1]["assessment"]["status"] = DECLARATION_MISMATCH
+    assert unexpected_mismatch_case_ids(artifact) == ("case_03",)

--- a/tests/test_benchmark_graph_expectations.py
+++ b/tests/test_benchmark_graph_expectations.py
@@ -1,0 +1,68 @@
+"""Regression tests for structured benchmark graph expectations."""
+
+import numpy as np
+
+import misda
+from misda.benchmark import (
+    BenchmarkCase,
+    DECLARATION_MATCH,
+    DECLARATION_MISMATCH,
+)
+
+
+def _two_group_result():
+    x = np.array([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0])
+    data = np.column_stack([x, 2.0 * x, -x, -2.0 * x])
+    return misda.discover(data, seed=19, name="two groups")
+
+
+def test_from_truth_preserves_structured_graph_expectations():
+    result = _two_group_result()
+    truth = {
+        "name": "two groups",
+        "latent_expected": 1,
+        "structural_expected": 2,
+        "blocks_expected": [["f1", "f2"], ["f3", "f4"]],
+        "graph_expected": "two positive components; one signed component",
+        "graph_expectations": {
+            "structural": {"edges": 2, "components": 2},
+            "dependence": {"edges": 6, "components": 1},
+        },
+    }
+
+    case = BenchmarkCase.from_truth("x", truth)
+    assert case.graph_expectations == truth["graph_expectations"]
+
+    assessment = case.evaluate(result)
+    graph_checks = [
+        check for check in assessment["checks"]
+        if check["field"].startswith("graphs.")
+    ]
+    assert graph_checks
+    assert all(check["status"] == DECLARATION_MATCH for check in graph_checks)
+
+
+def test_wrong_structured_graph_expectation_is_a_declaration_mismatch():
+    result = _two_group_result()
+    case = BenchmarkCase.from_truth(
+        "x",
+        {
+            "name": "wrong graph",
+            "latent_expected": 1,
+            "structural_expected": 2,
+            "blocks_expected": [["f1", "f2"], ["f3", "f4"]],
+            "graph_expectations": {
+                "structural": {"components": 1},
+            },
+        },
+    )
+
+    assessment = case.evaluate(result)
+    graph_check = next(
+        check for check in assessment["checks"]
+        if check["field"] == "graphs.structural.components"
+    )
+    assert graph_check["observed"] == 2
+    assert graph_check["expected"] == 1
+    assert graph_check["status"] == DECLARATION_MISMATCH
+    assert assessment["status"] == DECLARATION_MISMATCH

--- a/tests/test_benchmark_report_assessment.py
+++ b/tests/test_benchmark_report_assessment.py
@@ -1,5 +1,7 @@
 """Regression tests for notebook-visible benchmark declaration assessment."""
 
+from types import SimpleNamespace
+
 import numpy as np
 
 import misda
@@ -36,15 +38,21 @@ def test_public_benchmark_report_exposes_structured_declaration_checks():
 
 def test_public_benchmark_report_exposes_expected_mismatch_reason():
     result = _result()
+    result.support = SimpleNamespace(
+        status="UNSUPPORTED",
+        results=(SimpleNamespace(reasons=("HIDDEN_SPECTRAL_STRUCTURE",)),),
+    )
     observed = misda.benchmark(
         result,
         {
             "latent_expected": 4,
-            "expected_mismatches": {"latent_dimension": "KNOWN_LIMITATION"},
+            "expected_mismatches": {
+                "latent_dimension": "HIDDEN_SPECTRAL_STRUCTURE"
+            },
         },
     )
 
     assert observed.assessment["status"] == EXPECTED_DECLARATION_MISMATCH
     report = observed.report()
     assert "latent_dimension: status=EXPECTED_DECLARATION_MISMATCH" in report
-    assert "reason=KNOWN_LIMITATION" in report
+    assert "reason=HIDDEN_SPECTRAL_STRUCTURE" in report

--- a/tests/test_benchmark_report_assessment.py
+++ b/tests/test_benchmark_report_assessment.py
@@ -1,0 +1,50 @@
+"""Regression tests for notebook-visible benchmark declaration assessment."""
+
+import numpy as np
+
+import misda
+from misda.benchmark import (
+    DECLARATION_MISMATCH,
+    EXPECTED_DECLARATION_MISMATCH,
+)
+
+
+def _result():
+    x = np.array([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0])
+    data = np.column_stack([x, 2.0 * x, -x, -2.0 * x])
+    return misda.discover(data, seed=19, name="two groups")
+
+
+def test_public_benchmark_report_exposes_structured_declaration_checks():
+    result = _result()
+    observed = misda.benchmark(
+        result,
+        {
+            "name": "wrong topology declaration",
+            "latent_expected": 1,
+            "structural_expected": 2,
+            "graph_expectations": {"structural": {"components": 1}},
+        },
+    )
+
+    assert observed.assessment["status"] == DECLARATION_MISMATCH
+    report = observed.report()
+    assert "Declaration assessment" in report
+    assert "Status         : DECLARATION_MISMATCH" in report
+    assert "graphs.structural.components: status=DECLARATION_MISMATCH" in report
+
+
+def test_public_benchmark_report_exposes_expected_mismatch_reason():
+    result = _result()
+    observed = misda.benchmark(
+        result,
+        {
+            "latent_expected": 4,
+            "expected_mismatches": {"latent_dimension": "KNOWN_LIMITATION"},
+        },
+    )
+
+    assert observed.assessment["status"] == EXPECTED_DECLARATION_MISMATCH
+    report = observed.report()
+    assert "latent_dimension: status=EXPECTED_DECLARATION_MISMATCH" in report
+    assert "reason=KNOWN_LIMITATION" in report

--- a/tests/test_benchmark_report_evidence.py
+++ b/tests/test_benchmark_report_evidence.py
@@ -1,0 +1,47 @@
+"""Regression tests for rich observed evidence in benchmark reports."""
+
+import numpy as np
+
+import misda
+
+
+def _evaluated_result():
+    x = np.array([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0])
+    data = np.column_stack([x, 2.0 * x, -x, -2.0 * x])
+    result = misda.discover(data, seed=19, name="two groups")
+    misda.evaluate(result, metrics=("linear", "pareto"), candidates="all")
+    return result
+
+
+def test_report_exposes_observed_evidence_without_external_metric_truth():
+    result = _evaluated_result()
+    observed = misda.benchmark(result, {"name": "observed evidence"})
+
+    report = observed.report()
+
+    assert "Candidate evaluation evidence" in report
+    assert f"Linear scope   : {len(result)}/{len(result)} candidates" in report
+    assert "Linear selected: mean_r2=" in report
+    assert "Linear across  : mean_r2 min=" in report
+    assert "worst_r2 min=" in report
+    assert f"Pareto scope   : {len(result)}/{len(result)} candidates" in report
+    assert "Pareto selected: retention=" in report
+    assert "Pareto fronts  : full=" in report
+    assert "Pareto across  : retention min=" in report
+    assert "Pareto across  : validity min=" in report
+    assert "Pareto across  : jaccard min=" in report
+    assert "Pareto declaration agreement" in report
+    assert "N/A — pareto_expected was not declared" in report
+
+
+def test_report_states_when_candidate_families_were_not_evaluated():
+    data = np.eye(6, 4)
+    result = misda.discover(data, seed=7)
+    observed = misda.benchmark(result, {})
+
+    report = observed.report()
+
+    assert "Linear scope   : not evaluated" in report
+    assert "Linear selected: N/A" in report
+    assert "Pareto scope   : not evaluated" in report
+    assert "Pareto selected: N/A" in report

--- a/tests/test_benchmark_v2.py
+++ b/tests/test_benchmark_v2.py
@@ -49,6 +49,7 @@ def test_public_benchmark_preserves_external_truth():
         "latent_expected": 1,
         "structural_expected": 2,
         "blocks_expected": [["f3", "f4"], ["f1", "f2"]],
+        "components_expected": [["f3", "f4"], ["f1", "f2"]],
         "pareto_expected": [0, 1, 2, 3],
         "feature": "two antagonistic families",
         "intuition": "one representative per family",
@@ -64,6 +65,7 @@ def test_public_benchmark_preserves_external_truth():
     assert observed.name == truth["name"]
     assert observed.feature == truth["feature"]
     assert observed.blocks_expected == (("f3", "f4"), ("f1", "f2"))
+    assert observed.components_expected == (("f3", "f4"), ("f1", "f2"))
     assert not hasattr(result.analysis, "latent_expected")
     assert not hasattr(result.analysis, "structural_expected")
 
@@ -75,7 +77,7 @@ def test_benchmark_compares_dimensions_and_partition_to_graph_outputs():
         {
             "latent_expected": 1,
             "structural_expected": 2,
-            "blocks_expected": [["f3", "f4"], ["f1", "f2"]],
+            "components_expected": [["f3", "f4"], ["f1", "f2"]],
         },
     )
 
@@ -88,6 +90,21 @@ def test_benchmark_compares_dimensions_and_partition_to_graph_outputs():
     assert observed.structural_precision == 1.0
     assert observed.structural_recall == 1.0
     assert observed.structural_partition_exact
+
+
+def test_blocks_do_not_implicitly_declare_connected_components():
+    _data, result = _two_group_result()
+    observed = misda.benchmark(
+        result,
+        {"blocks_expected": [["f1", "f2", "f3", "f4"]]},
+    )
+
+    assert observed.blocks_expected == (("f1", "f2", "f3", "f4"),)
+    assert observed.components_expected is None
+    assert observed.structural_jaccard is None
+    assert observed.unavailable_reasons["structural"] == (
+        "components_expected was not declared"
+    )
 
 
 def test_benchmark_pareto_uses_stored_selected_candidate_evidence_only():
@@ -126,13 +143,13 @@ def test_missing_declarations_are_explicit_na():
     assert observed.structural_jaccard is None
     assert observed.pareto_recall is None
     assert observed.unavailable_reasons == {
-        "structural": "blocks_expected was not declared",
+        "structural": "components_expected was not declared",
         "pareto": "pareto_expected was not declared",
         "latent_dimension": "latent_expected was not declared",
         "structural_dimension": "structural_expected was not declared",
     }
     report = observed.report()
-    assert "N/A — blocks_expected was not declared" in report
+    assert "N/A — components_expected was not declared" in report
     assert "N/A — pareto_expected was not declared" in report
 
 


### PR DESCRIPTION
## Purpose

Correct the benchmark infrastructure after the post-merge semantic audit, without changing MISDA's discovery/evaluation algorithms.

Each correction is kept in a separate commit and tested. The notebook remains the scientific reference; the automated runner now follows it.

## Corrected benchmark semantics

- `blocks_expected` and `components_expected` are separate declarations; connected-component expectations are never inferred from declared dimension.
- Graph expectations are structured and checked explicitly.
- Expected declaration mismatches are field-specific and are accepted only when the corresponding internal dimensional-support diagnostic is actually observed.
- Case 5 dimensional mismatches are tied to observed `TRANSITIVE_CHAINING` evidence.
- MOP-F dimensional/unit mismatches are tied to observed `HIDDEN_SPECTRAL_STRUCTURE` evidence.
- `--quick` is smoke-only and cannot define or fail a scientific baseline.
- The scientific runner uses the notebook reference scope: `N=300`, linear + Pareto evaluation for all candidates.
- `--strict` fails only on unexpected declaration mismatches and reports them per field.
- Benchmark reports expose candidate-evaluation scope/evidence and structured declaration assessment.
- The benchmark acceptance rules are recorded in `docs/decisions.md` §9.1.

## Acceptance

Final head: `c0a4aead776c68eef8c56266d710f611ab942bc1`

GitHub Actions `newapi gate` run #95 succeeded:

- full test suite: passed;
- canonical 13-case scientific battery at `N=300`: passed under `--strict`;
- three comparative experiments: passed.

The previous code-bearing gate (#94) reported 187 passing tests; the final documentation-only commit was revalidated by the complete gate in run #95.

The PR changes benchmark declarations, benchmark/reporting infrastructure, tests, the decision ledger, and the acceptance workflow only. No discovery/evaluation algorithm module is changed.