### PR TITLE
Fix rank-deficient linear PRESS and Case 5 graph declaration

### DIFF
--- a/misda/_reconstruction.py
+++ b/misda/_reconstruction.py
@@ -28,8 +28,15 @@ def _explicit_loo_predictions(data, selected, eliminated):
 def _press_predictions(data, selected, eliminated):
     design = np.column_stack((np.ones(data.shape[0]), data[:, selected]))
     try:
-        Q, _ = np.linalg.qr(design, mode="reduced")
+        Q, R = np.linalg.qr(design, mode="reduced")
         if Q.shape[1] < design.shape[1]:
+            return _explicit_loo_predictions(data, selected, eliminated)
+        rank_tolerance = (
+            np.finfo(float).eps
+            * max(design.shape)
+            * max(1.0, float(np.linalg.norm(R, ord=np.inf)))
+        )
+        if np.any(np.abs(np.diag(R)) <= rank_tolerance):
             return _explicit_loo_predictions(data, selected, eliminated)
         targets = data[:, eliminated]
         fitted = Q @ (Q.T @ targets)

--- a/misda/benchmarks/cases.py
+++ b/misda/benchmarks/cases.py
@@ -165,14 +165,18 @@ def make_case5_chain_structure(N=1000, M=20, seed=123):
         latent_expected=M,
         structural_expected=M,
         blocks_expected=[cols],
-        feature="Markovian random walk chain where correlation decays smoothly with index distance.",
-        intuition="A chain of 20 dominoes: adjacent dominoes are strongly linked, but the 1st and 20th are far apart. Tests gradual, step-by-step continuous dependency.",
-        graph_expected="1 connected chain/band graph (adjacent node edges, 1 connected component)",
-        graph_expectations={"structural": {"components": 1}},
+        feature="Cumulative random-walk chain with one independent innovation added at each objective; pairwise correlations decay with index distance but remain strongly positive at this noise scale.",
+        intuition="Each objective adds new information to the previous one, so the generating dimension remains 20 even though accumulated pairwise correlation can make all objectives pass the positive-dependence threshold. This is the intended transitive-chaining failure mode.",
+        graph_expected="Thresholded positive/dependence graph saturates to K_20 (190 edges, 1 connected component) even though the generating mechanism is a chain.",
+        graph_expectations={
+            "structural": {"edges": 190, "components": 1},
+            "dependence": {"edges": 190, "components": 1},
+        },
         expected_mismatches={
             "latent_dimension": "TRANSITIVE_CHAINING",
             "structural_dimension": "TRANSITIVE_CHAINING",
         },
+        notes="The complete threshold graph is not ground-truth redundancy: TRANSITIVE_CHAINING is expected to flag the collapse from the 20-dimensional generating process to graph-derived dimension 1.",
     )
     return df, truth
 

--- a/tests/test_case5_chain_declaration.py
+++ b/tests/test_case5_chain_declaration.py
@@ -1,0 +1,21 @@
+"""Regression tests for the Case 5 transitive-chaining declaration."""
+
+from misda.benchmarks.cases import make_case5_chain_structure
+
+
+def test_case5_declares_complete_threshold_graph_but_full_generating_dimension():
+    _frame, truth = make_case5_chain_structure(N=300, seed=123)
+
+    assert truth["latent_expected"] == 20
+    assert truth["structural_expected"] == 20
+    assert truth["graph_expectations"] == {
+        "structural": {"edges": 190, "components": 1},
+        "dependence": {"edges": 190, "components": 1},
+    }
+    assert "K_20" in truth["graph_expected"]
+    assert "generating mechanism is a chain" in truth["graph_expected"]
+    assert truth["expected_mismatches"] == {
+        "latent_dimension": "TRANSITIVE_CHAINING",
+        "structural_dimension": "TRANSITIVE_CHAINING",
+    }
+    assert "not ground-truth redundancy" in truth["notes"]

--- a/tests/test_linear_rank_deficiency.py
+++ b/tests/test_linear_rank_deficiency.py
@@ -1,0 +1,53 @@
+"""Regression tests for rank-deficient linear PRESS designs."""
+
+import numpy as np
+
+from misda import _reconstruction
+
+
+def _rank_deficient_example(n=80):
+    rng = np.random.default_rng(123)
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = 1.0 - x
+    target = x**2
+    return np.column_stack([x, y, target])
+
+
+def test_press_falls_back_to_explicit_loo_for_rank_deficient_design(monkeypatch):
+    data = _rank_deficient_example()
+    selected = (0, 1)
+    eliminated = (2,)
+    expected = _reconstruction._explicit_loo_predictions(
+        data, selected, eliminated
+    )
+
+    original = _reconstruction._explicit_loo_predictions
+    calls = []
+
+    def spy(*args, **kwargs):
+        calls.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(_reconstruction, "_explicit_loo_predictions", spy)
+    observed = _reconstruction._press_predictions(data, selected, eliminated)
+
+    assert calls
+    np.testing.assert_allclose(observed, expected, rtol=0.0, atol=0.0)
+
+
+def test_press_keeps_fast_qr_path_for_full_rank_design(monkeypatch):
+    rng = np.random.default_rng(42)
+    data = rng.normal(size=(80, 5))
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("full-rank design unexpectedly used explicit LOO")
+
+    monkeypatch.setattr(
+        _reconstruction,
+        "_explicit_loo_predictions",
+        fail_if_called,
+    )
+    observed = _reconstruction._press_predictions(data, (0, 1), (2, 3, 4))
+
+    assert observed.shape == (80, 3)
+    assert np.all(np.isfinite(observed))


### PR DESCRIPTION
## Purpose

Correct the two concrete problems exposed by the executed `benchmark.ipynb` results, without changing MISDA discovery semantics.

## Changes

### 1. Rank-deficient linear PRESS

- Detect rank-deficient design matrices from the QR factor `R`.
- When rank deficiency is detected, use the existing explicit leave-one-out pseudoinverse path instead of applying the PRESS leverage formula to an invalid full-rank factorization.
- This addresses MOP-D, where the selected predictors can contain `x` and `1-x` together with an intercept.
- Full-rank designs retain the existing QR fast path.

### 2. Case 5 benchmark truth

- Keep the generator and the 20-dimensional generating truth unchanged.
- Correct the graph declaration to describe what the benchmark actually produces at `N=300, seed=123`: thresholded `G+` and `G±` saturate to `K_20` (190 edges, one component).
- Preserve the dimensional mismatch as an intentional `TRANSITIVE_CHAINING` failure mode, and state explicitly that the complete threshold graph is not ground-truth redundancy.

## Pre-commit validation

Each correction was validated before its commit.

- Rank-deficient MOP-D-like design: corrected PRESS path took the explicit-LOO fallback and matched it exactly; the old QR path differed materially.
- Full-rank random design: corrected path stayed on QR and matched the previous implementation exactly.
- Case 5 `N=300, seed=123`: executed notebook reports `latent=1`, `structural=1`; with 20 vertices this implies a complete graph. Regenerated data also showed minimum pairwise Pearson correlation about 0.765, consistent with saturation.

## Commits

- `3eec79a3aee18d6a756373946d47f8b5c65118c7` — `fix(linear): detect rank-deficient PRESS designs`
- `c1d7c383694483065b5ec53eda885b26c2a10cb0` — `fix(benchmark): align Case 5 graph truth with chaining failure`

## Final validation

GitHub Actions `newapi gate` run #96 succeeded on final head `c1d7c383694483065b5ec53eda885b26c2a10cb0`:

- full suite: **190 passed** in 68.63 s;
- canonical scientific battery: **passed under `--strict`** at the notebook-reference `N=300`, evaluating linear + Pareto for all candidates;
- comparative experiments: **passed**.

The strict Case 5 graph checks now include 190 structural edges, 190 dependence edges, and one component in each graph; therefore the successful canonical gate verifies the corrected graph declaration against the reference execution.

Fixes #9