### PR TITLE
Strengthen benchmark graph expectations

### DIFF
--- a/misda/benchmarks/mop.py
+++ b/misda/benchmarks/mop.py
@@ -91,8 +91,11 @@ def mopA_monotonic_redundancy(N=1000, seed=123, noise=0.0):
         notes="20 objectives as monotonic (and redundant) transformations of the same latent x.",
         feature="20 non-linear monotonic transformations driven by a single 1D decision variable x.",
         intuition="20 different formulas (squares, roots, logs) calculated from a single input x. Since all move in sync, MISDA should collapse all 20 to 1.",
-        graph_expected="1 fully connected graph (K_20, 190 edges, 1 connected component)",
-        graph_expectations={"structural": {"components": 1}},
+        graph_expected="G+ and G± are K_20 (20 nodes, 190 edges, 1 connected component).",
+        graph_expectations={
+            "structural": {"nodes": 20, "edges": 190, "components": 1},
+            "dependence": {"nodes": 20, "edges": 190, "components": 1},
+        },
     )
     return _mop_df(Y), truth
 
@@ -153,8 +156,11 @@ def mopB_tradeoff_with_redundancies(N=1000, seed=123, noise=0.02):
         notes="Three families (cost/consumption/performance) with internal redundancies; effective tends to ~2.",
         feature="Three functional engineering families (7 cost, 7 consumption, 6 performance) driven by 2 decision variables.",
         intuition="An engineering problem with 3 main goals: Cost, Energy, and Performance, each measured in multiple redundant ways. MISDA should shrink 20 to ~2-3 core trade-offs.",
-        graph_expected="1 connected graph with 3 dense functional clusters (1 connected component, effective dim ~2)",
-        graph_expectations={"structural": {"components": 1}},
+        graph_expected="G+ is one connected 20-node graph; the 3 generating families are declared separately from graph topology.",
+        graph_expectations={
+            "structural": {"nodes": 20, "components": 1},
+            "dependence": {"nodes": 20, "components": 1},
+        },
     )
     return _mop_df(Y), truth
 
@@ -181,8 +187,11 @@ def mopC_latent_blocks_4x5(N=1000, seed=123, noise=0.02):
         notes="Four independent factors; each block (5 objectives) is internally redundant.",
         feature="4 independent decision factors; each factor generates a block of 5 non-linearly transformed objectives.",
         intuition="4 control dials, where turning each dial affects 5 non-linear indicators. MISDA should extract 4 independent representatives (1 per dial).",
-        graph_expected="4 disjoint dense subgraphs of 5 nodes each (4 x K_5, 4 connected components)",
-        graph_expectations={"structural": {"components": 4}},
+        graph_expected="G+ and G± are 4 disjoint K_5 components (20 nodes, 40 edges, 4 connected components).",
+        graph_expectations={
+            "structural": {"nodes": 20, "edges": 40, "components": 4},
+            "dependence": {"nodes": 20, "edges": 40, "components": 4},
+        },
     )
     return _mop_df(Y), truth
 
@@ -229,10 +238,10 @@ def mopD_pure_conflict_groups(N=1000, seed=123, noise=0.0):
         notes="Two internally redundant groups (+x and 1-x), but antagonistic to each other: conflict must be preserved.",
         feature="Two antagonistic non-linear objective families (+x vs 1-x) with internal redundancy and trade-off conflict.",
         intuition="10 indicators measuring Benefit (+x) vs 10 measuring Risk (1-x). Benefit and Risk directly conflict. MISDA must preserve 1 Benefit and 1 Risk indicator.",
-        graph_expected="2 disjoint complete subgraphs of 10 nodes each (2 x K_10, 90 total edges, 2 connected components)",
+        graph_expected="G+ is 2 disjoint K_10 components (20 nodes, 90 edges); G± is K_20 because the groups are mutually antagonistic.",
         graph_expectations={
-            "structural": {"components": 2},
-            "dependence": {"components": 1},
+            "structural": {"nodes": 20, "edges": 90, "components": 2},
+            "dependence": {"nodes": 20, "edges": 190, "components": 1},
         },
     )
     return _mop_df(Y), truth
@@ -287,8 +296,11 @@ def mopE_partial_redundancy_noisy(N=1000, seed=123, noise=0.05):
         notes="Trio/quartet of 'a' extended to 10 redundants; 'b' (4); and 6 compounds around s=a+b.",
         feature="Partial redundancy across 2 latent drivers (a,b): 10 objectives on a, 4 on b, and 6 compounds on s=a+b.",
         intuition="Overlapping signals: some indicators monitor Engine A, some monitor Engine B, and some monitor both combined (A+B). Tests if MISDA untangles blended signals.",
-        graph_expected="1 connected graph with 3 dense overlapping clusters (Subfamily A: 10, B: 4, C: 6)",
-        graph_expectations={"structural": {"components": 1}},
+        graph_expected="G+ is one connected 20-node graph; the A, B, and A+B generating families are declared separately from graph topology.",
+        graph_expectations={
+            "structural": {"nodes": 20, "components": 1},
+            "dependence": {"nodes": 20, "components": 1},
+        },
     )
     return _mop_df(Y), truth
 
@@ -342,8 +354,11 @@ def mopF_regime_switching(N=1000, seed=123, sharpness=20.0, noise=0.0):
         notes="10 objectives redundant around L (mixture by regime) + 10 redundant around b; global correlation can be misleading.",
         feature="Non-linear regime-switching mixture: 10 objectives on regime-dependent mixture L(a,b) and 10 on b.",
         intuition="System switching: indicators change behavior depending on whether the system operates in High-Power or Low-Power mode. Tests MISDA under shifting states.",
-        graph_expected="1 connected graph with 2 dense interconnected clusters (10 on mixture L, 10 on b)",
-        graph_expectations={"structural": {"components": 1}},
+        graph_expected="At the canonical threshold, G+ and G± saturate to K_20 (20 nodes, 190 edges, 1 connected component), hiding the 2-driver generating structure.",
+        graph_expectations={
+            "structural": {"nodes": 20, "edges": 190, "components": 1},
+            "dependence": {"nodes": 20, "edges": 190, "components": 1},
+        },
         expected_mismatches={
             "latent_dimension": "HIDDEN_SPECTRAL_STRUCTURE",
             "structural_dimension": "HIDDEN_SPECTRAL_STRUCTURE",

--- a/tests/test_mop_graph_declarations.py
+++ b/tests/test_mop_graph_declarations.py
@@ -1,0 +1,49 @@
+"""Regression tests for machine-verifiable MOP graph declarations."""
+
+from misda.benchmarks.mop import (
+    mopA_monotonic_redundancy,
+    mopB_tradeoff_with_redundancies,
+    mopC_latent_blocks_4x5,
+    mopD_pure_conflict_groups,
+    mopE_partial_redundancy_noisy,
+    mopF_regime_switching,
+)
+
+
+def _truth(generator):
+    _data, truth = generator(N=64, seed=123)
+    return truth
+
+
+def test_exact_mop_graph_claims_are_structured_exactly():
+    expected = {
+        mopA_monotonic_redundancy: {
+            "structural": {"nodes": 20, "edges": 190, "components": 1},
+            "dependence": {"nodes": 20, "edges": 190, "components": 1},
+        },
+        mopC_latent_blocks_4x5: {
+            "structural": {"nodes": 20, "edges": 40, "components": 4},
+            "dependence": {"nodes": 20, "edges": 40, "components": 4},
+        },
+        mopD_pure_conflict_groups: {
+            "structural": {"nodes": 20, "edges": 90, "components": 2},
+            "dependence": {"nodes": 20, "edges": 190, "components": 1},
+        },
+        mopF_regime_switching: {
+            "structural": {"nodes": 20, "edges": 190, "components": 1},
+            "dependence": {"nodes": 20, "edges": 190, "components": 1},
+        },
+    }
+
+    for generator, graph_expectations in expected.items():
+        assert _truth(generator)["graph_expectations"] == graph_expectations
+
+
+def test_qualitative_generating_families_are_not_misdeclared_as_graph_clusters():
+    for generator in (mopB_tradeoff_with_redundancies, mopE_partial_redundancy_noisy):
+        truth = _truth(generator)
+        assert truth["graph_expectations"] == {
+            "structural": {"nodes": 20, "components": 1},
+            "dependence": {"nodes": 20, "components": 1},
+        }
+        assert "declared separately from graph topology" in truth["graph_expected"]


### PR DESCRIPTION
## Purpose

Make the machine-checked `graph_expectations` as strong as the graph claims the canonical MOP benchmark is actually intended to make.

## Changes

- MOP-A: explicitly checks 20 nodes, 190 edges and 1 component in both G+ and G±.
- MOP-C: explicitly checks four K5 components (20 nodes, 40 edges) in both graphs.
- MOP-D: explicitly checks G+ = 2 x K10 (90 edges, 2 components) and G± = K20 (190 edges, 1 component).
- MOP-F: aligns the graph declaration with its intended hidden-structure failure mode: the thresholded graphs saturate to K20 while the generating mechanism remains 2D.
- MOP-B and MOP-E: remove the misleading implication that generating families are machine-verified graph clusters; their graph declarations now state only the connected-topology invariants actually checked, while families remain declared separately.
- Adds regression tests for all six MOP declarations.

No discovery/evaluation algorithm behavior is changed.

## Validation

Pre-commit consistency checks covered clique edge counts and the 20-node invariants.

GitHub Actions `newapi gate` run #97 succeeded on the PR head:
- full suite: **192 passed** in 45.31 s;
- canonical scientific battery: **passed under `--strict`** at `N=300`;
- comparative experiments: **passed**.

Thus the strengthened machine declarations were exercised against the actual canonical benchmark rather than only checked statically.

Fixes #10