### PR TITLE
Preserve benchmark JSON outputs as workflow artifacts

### DIFF
--- a/.github/workflows/newapi.yml
+++ b/.github/workflows/newapi.yml
@@ -23,5 +23,19 @@ jobs:
         run: pytest -q
       - name: Canonical scientific battery
         run: python -m examples.benchmarks.run_benchmark --strict --output /tmp/misda-benchmark.json
+      - name: Preserve canonical benchmark artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: misda-benchmark
+          path: /tmp/misda-benchmark.json
+          if-no-files-found: warn
       - name: Comparative experiments
         run: python -m examples.benchmarks.run_comparative --output /tmp/misda-comparative.json
+      - name: Preserve comparative artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: misda-comparative
+          path: /tmp/misda-comparative.json
+          if-no-files-found: warn

--- a/tests/test_workflow_artifacts.py
+++ b/tests/test_workflow_artifacts.py
@@ -1,0 +1,14 @@
+"""Regression guard for benchmark artifacts in the acceptance workflow."""
+
+from pathlib import Path
+
+
+def test_acceptance_workflow_preserves_benchmark_json_artifacts():
+    workflow = Path(".github/workflows/newapi.yml").read_text(encoding="utf-8")
+
+    assert "uses: actions/upload-artifact@v4" in workflow
+    assert "name: misda-benchmark" in workflow
+    assert "path: /tmp/misda-benchmark.json" in workflow
+    assert "name: misda-comparative" in workflow
+    assert "path: /tmp/misda-comparative.json" in workflow
+    assert workflow.count("if: always()") >= 2


### PR DESCRIPTION
## Purpose

Keep the machine-readable outputs of the scientific benchmark and comparative runs available after the ephemeral GitHub Actions runner is destroyed.

## Changes

- Upload `/tmp/misda-benchmark.json` as artifact `misda-benchmark`.
- Upload `/tmp/misda-comparative.json` as artifact `misda-comparative`.
- Use `if: always()` so an output that was produced before a later failure is still preserved.
- Use `if-no-files-found: warn` so artifact preservation does not mask the original scientific/runtime failure.
- Add a regression guard for both artifact steps.

The benchmark/comparative commands and scientific semantics are unchanged.

## Validation

The proposed workflow parsed successfully before the implementation commit.

GitHub Actions `newapi gate` run #98 succeeded on the PR head:
- full suite: **191 passed** in 44.14 s;
- canonical scientific battery: **passed under `--strict`**;
- comparative experiments: **passed**;
- artifact `misda-benchmark`: uploaded successfully (66,479 bytes);
- artifact `misda-comparative`: uploaded successfully (24,927 bytes).

The run's artifact API confirms both artifacts are present and downloadable, so this was validated end-to-end rather than only by inspecting the YAML.

Fixes #11