### PR TITLE
Run acceptance workflow on main merges

### DIFF
--- a/.github/workflows/newapi.yml
+++ b/.github/workflows/newapi.yml
@@ -1,8 +1,8 @@
-name: newapi gate
+name: acceptance gate
 
 on:
   push:
-    branches: [newapi]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/tests/test_workflow_artifacts.py
+++ b/tests/test_workflow_artifacts.py
@@ -1,10 +1,14 @@
-"""Regression guard for benchmark artifacts in the acceptance workflow."""
+"""Regression guards for the benchmark acceptance workflow."""
 
 from pathlib import Path
 
 
+def _workflow_text():
+    return Path(".github/workflows/newapi.yml").read_text(encoding="utf-8")
+
+
 def test_acceptance_workflow_preserves_benchmark_json_artifacts():
-    workflow = Path(".github/workflows/newapi.yml").read_text(encoding="utf-8")
+    workflow = _workflow_text()
 
     assert "uses: actions/upload-artifact@v4" in workflow
     assert "name: misda-benchmark" in workflow
@@ -12,3 +16,12 @@ def test_acceptance_workflow_preserves_benchmark_json_artifacts():
     assert "name: misda-comparative" in workflow
     assert "path: /tmp/misda-comparative.json" in workflow
     assert workflow.count("if: always()") >= 2
+
+
+def test_acceptance_workflow_runs_for_main_prs_and_pushes():
+    workflow = _workflow_text()
+
+    assert "name: acceptance gate" in workflow
+    assert "  push:\n    branches: [main]\n" in workflow
+    assert "  pull_request:\n    branches: [main]\n" in workflow
+    assert "newapi" not in workflow


### PR DESCRIPTION
## Purpose

Remove the stale `newapi` workflow trigger and run the acceptance gate on the revision actually integrated into `main` after a merge.

## Changes

- rename the workflow from `newapi gate` to `acceptance gate`;
- change `push.branches` from the retired `newapi` branch to `main`;
- keep pull-request validation for PRs targeting `main`;
- preserve the existing full test, canonical scientific battery, comparative run, and JSON artifact publication steps;
- add a regression guard for both the PR and push triggers.

## Validation

The proposed YAML parsed successfully before the implementation commit and was checked to contain `push -> main`, `pull_request -> main`, both artifact upload steps, and no residual `newapi` reference.

GitHub Actions run #100 succeeded on the PR head under the renamed `acceptance gate` workflow:
- full suite: **194 passed in 68.21 s**;
- canonical scientific battery: **passed under `--strict` at N=300**;
- comparative experiments: **passed**;
- benchmark artifact uploaded successfully (66,681 bytes);
- comparative artifact uploaded successfully (24,824 bytes).

Fixes #15