### PR TITLE
perf: accelerate full-candidate linear jackknife evaluation

### DIFF
--- a/misda/_linear.py
+++ b/misda/_linear.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2025 Monaco F. J. <monaco@usp.br>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Performance-preserving linear reconstruction for full-candidate evaluation.
+
+The public semantics are the same as ``_reconstruction.evaluate_linear_reconstruction``:
+external PRESS/LOO R² with delete-one jackknife uncertainty.  For regular full-rank
+OLS designs, the jackknife is obtained from one QR factorization using exact case-
+deletion identities instead of recomputing a QR factorization for every omitted
+sample.  Numerically delicate or rank-deficient cases fall back to the reference
+implementation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._reconstruction import (
+    _jackknife_standard_error,
+    _r2_metrics,
+    evaluate_linear_reconstruction as _reference_linear_reconstruction,
+)
+
+
+def _fast_jackknife_r2(data, selected, eliminated):
+    """Return delete-one jackknife R² values, or ``None`` when fallback is safer.
+
+    For a full-data OLS fit with residual vector ``e`` and hat matrix ``H``, the
+    prediction residual for observation ``i`` after observations ``i`` and ``j``
+    are deleted is obtained from the 2x2 case-deletion system
+
+        r_ij = ((1-h_jj)e_i + h_ij e_j)
+               / ((1-h_ii)(1-h_jj) - h_ij**2).
+
+    For jackknife replicate ``j``, these are exactly the PRESS residuals of the
+    dataset with row ``j`` removed.  Thus all N jackknife replicates can be
+    computed from one QR factorization of the full design.
+    """
+
+    matrix = np.asarray(data, dtype=float)
+    n_samples = matrix.shape[0]
+    design = np.column_stack((np.ones(n_samples), matrix[:, selected]))
+
+    # A delete-one dataset must still contain enough rows for the regular
+    # full-rank path.  The reference implementation remains authoritative for
+    # small or degenerate cases.
+    if n_samples <= design.shape[1] + 1:
+        return None
+
+    try:
+        q, r = np.linalg.qr(design, mode="reduced")
+    except np.linalg.LinAlgError:
+        return None
+
+    if q.shape[1] < design.shape[1]:
+        return None
+    rank_tolerance = (
+        np.finfo(float).eps
+        * max(design.shape)
+        * max(1.0, float(np.linalg.norm(r, ord=np.inf)))
+    )
+    if np.any(np.abs(np.diag(r)) <= rank_tolerance):
+        return None
+
+    targets = matrix[:, eliminated]
+    fitted = q @ (q.T @ targets)
+    residuals = targets - fitted
+    hat = q @ q.T
+    one_minus_leverage = 1.0 - np.diag(hat)
+
+    press_tolerance = np.finfo(float).eps * max(
+        10.0, float(design.shape[1])
+    )
+    if np.any(np.abs(one_minus_leverage) <= press_tolerance):
+        return None
+
+    # Pair-deletion denominators.  A near-zero value indicates that at least
+    # one reduced design is numerically singular; defer such cases to the
+    # reference implementation, which performs its established explicit-LOO
+    # fallback when necessary.
+    denominator = (
+        one_minus_leverage[:, np.newaxis]
+        * one_minus_leverage[np.newaxis, :]
+        - hat * hat
+    )
+    off_diagonal = ~np.eye(n_samples, dtype=bool)
+    if np.any(np.abs(denominator[off_diagonal]) <= press_tolerance):
+        return None
+
+    means = np.mean(targets, axis=0)
+    full_sst = np.sum((targets - means) ** 2, axis=0)
+    if np.any(full_sst <= np.finfo(float).eps):
+        return None
+
+    deleted_sst = (
+        full_sst[np.newaxis, :]
+        - (n_samples / (n_samples - 1.0))
+        * (targets - means[np.newaxis, :]) ** 2
+    )
+    if np.any(deleted_sst <= np.finfo(float).eps):
+        return None
+
+    replicate_r2 = np.empty((n_samples, len(eliminated)), dtype=float)
+    for position in range(len(eliminated)):
+        e = residuals[:, position]
+        pair_residuals = (
+            e[:, np.newaxis] * one_minus_leverage[np.newaxis, :]
+            + hat * e[np.newaxis, :]
+        ) / denominator
+
+        # Column j represents the jackknife dataset with row j omitted.
+        # Row j itself is not part of that replicate.
+        np.fill_diagonal(pair_residuals, 0.0)
+        deleted_sse = np.sum(pair_residuals * pair_residuals, axis=0)
+        replicate_r2[:, position] = (
+            1.0 - deleted_sse / deleted_sst[:, position]
+        )
+
+    return replicate_r2
+
+
+def evaluate_linear_reconstruction(data, selected_indices, labels):
+    """Evaluate exact external linear reconstruction with fast jackknife.
+
+    The returned schema and statistical definitions match the reference engine.
+    The optimized path is used only for regular full-rank designs; every
+    numerically delicate case delegates to the reference implementation.
+    """
+
+    matrix = np.asarray(data, dtype=float)
+    if matrix.ndim != 2:
+        raise ValueError("data must be a two-dimensional matrix.")
+    n_samples, n_objectives = matrix.shape
+    selected = tuple(sorted(set(int(index) for index in selected_indices)))
+    if not selected:
+        raise ValueError("selected_indices must not be empty.")
+    if any(index < 0 or index >= n_objectives for index in selected):
+        raise IndexError("selected_indices contains an out-of-range objective.")
+    if len(labels) != n_objectives:
+        raise ValueError("labels must contain one value per objective.")
+
+    eliminated = tuple(
+        index for index in range(n_objectives) if index not in selected
+    )
+    if not eliminated:
+        return _reference_linear_reconstruction(matrix, selected, labels)
+
+    full = _r2_metrics(matrix, selected, eliminated, labels)
+    replicate_r2 = _fast_jackknife_r2(matrix, selected, eliminated)
+    if replicate_r2 is None:
+        return _reference_linear_reconstruction(matrix, selected, labels)
+
+    r2_se = {
+        labels[objective]: _jackknife_standard_error(
+            replicate_r2[:, position].tolist()
+        )
+        for position, objective in enumerate(eliminated)
+    }
+    mean_replicates = np.mean(replicate_r2, axis=1).tolist()
+    worst_replicates = np.min(replicate_r2, axis=1).tolist()
+
+    reason_by_metric = {}
+    if full["mean_r2"] is None:
+        reason_by_metric["mean_r2"] = "NO_DEFINED_TARGETS"
+    if full["worst_r2"] is None:
+        reason_by_metric["worst_r2"] = "NO_DEFINED_TARGETS"
+
+    return {
+        **full,
+        "reason_by_metric": reason_by_metric,
+        "jackknife": {
+            "r2_se_by_objective": r2_se,
+            "mean_r2_se": _jackknife_standard_error(mean_replicates),
+            "worst_r2_se": _jackknife_standard_error(worst_replicates),
+            "n_replicates": n_samples,
+            "reason": None,
+        },
+    }

--- a/misda/_linear.py
+++ b/misda/_linear.py
@@ -87,6 +87,11 @@ def _fast_jackknife_r2(data, selected, eliminated):
     if np.any(np.abs(denominator[off_diagonal]) <= press_tolerance):
         return None
 
+    # The diagonal corresponds to deleting the same observation twice and is
+    # not part of any jackknife replicate.  Give it a harmless denominator so
+    # vectorized division cannot emit a spurious divide-by-zero warning.
+    np.fill_diagonal(denominator, 1.0)
+
     means = np.mean(targets, axis=0)
     full_sst = np.sum((targets - means) ** 2, axis=0)
     if np.any(full_sst <= np.finfo(float).eps):

--- a/misda/api.py
+++ b/misda/api.py
@@ -13,11 +13,11 @@ import networkx as nx
 import numpy as np
 
 from ._graph import build_dependency_graphs, enumerate_structural_mis
+from ._linear import evaluate_linear_reconstruction
 from ._pareto import evaluate_pareto_preservation, get_nondominated_mask_minimize
 from ._ranking import compute_mis_metrics
 from ._reconstruction import (
     _derive_seed,
-    evaluate_linear_reconstruction,
     evaluate_nonlinear_reconstruction,
     evaluate_null_reconstruction,
 )

--- a/tests/test_linear_fast.py
+++ b/tests/test_linear_fast.py
@@ -1,0 +1,125 @@
+"""Regression contracts for the exact fast linear jackknife path."""
+
+import numpy as np
+
+from misda import _linear, _reconstruction
+from misda._tolerances import GATE_ATOL, GATE_RTOL
+
+
+def _assert_optional_close(observed, expected):
+    if expected is None:
+        assert observed is None
+    else:
+        assert np.isclose(
+            observed,
+            expected,
+            rtol=GATE_RTOL,
+            atol=GATE_ATOL,
+        )
+
+
+def _assert_linear_equivalent(observed, expected):
+    assert observed["r2_reason_by_objective"] == expected["r2_reason_by_objective"]
+    assert observed["reason_by_metric"] == expected["reason_by_metric"]
+
+    expected_r2 = expected["r2_by_objective"]
+    observed_r2 = observed["r2_by_objective"]
+    if expected_r2 is None:
+        assert observed_r2 is None
+    else:
+        assert set(observed_r2) == set(expected_r2)
+        for label in expected_r2:
+            _assert_optional_close(observed_r2[label], expected_r2[label])
+
+    _assert_optional_close(observed["mean_r2"], expected["mean_r2"])
+    _assert_optional_close(observed["worst_r2"], expected["worst_r2"])
+
+    observed_jackknife = observed["jackknife"]
+    expected_jackknife = expected["jackknife"]
+    assert observed_jackknife["n_replicates"] == expected_jackknife["n_replicates"]
+    assert observed_jackknife["reason"] == expected_jackknife["reason"]
+
+    expected_se = expected_jackknife["r2_se_by_objective"]
+    observed_se = observed_jackknife["r2_se_by_objective"]
+    if expected_se is None:
+        assert observed_se is None
+    else:
+        assert set(observed_se) == set(expected_se)
+        for label in expected_se:
+            _assert_optional_close(observed_se[label], expected_se[label])
+
+    _assert_optional_close(
+        observed_jackknife["mean_r2_se"],
+        expected_jackknife["mean_r2_se"],
+    )
+    _assert_optional_close(
+        observed_jackknife["worst_r2_se"],
+        expected_jackknife["worst_r2_se"],
+    )
+
+
+def test_fast_linear_jackknife_matches_reference_with_gate_tolerance():
+    rng = np.random.default_rng(20260911)
+    sources = rng.normal(size=(48, 3))
+    targets = sources @ np.array(
+        [
+            [1.2, -0.4, 0.6],
+            [0.3, 1.5, -0.2],
+            [-0.8, 0.2, 1.1],
+        ]
+    ) + rng.normal(scale=0.15, size=(48, 3))
+    data = np.column_stack((sources, targets))
+    labels = tuple(f"f{index + 1}" for index in range(data.shape[1]))
+    selected = (0, 1, 2)
+
+    expected = _reconstruction.evaluate_linear_reconstruction(
+        data,
+        selected,
+        labels,
+    )
+    observed = _linear.evaluate_linear_reconstruction(
+        data,
+        selected,
+        labels,
+    )
+
+    _assert_linear_equivalent(observed, expected)
+
+
+def test_regular_design_uses_fast_path(monkeypatch):
+    rng = np.random.default_rng(1109)
+    data = rng.normal(size=(40, 6))
+    labels = tuple(f"f{index + 1}" for index in range(data.shape[1]))
+
+    def fail_reference(*_args, **_kwargs):
+        raise AssertionError("regular design unexpectedly used reference fallback")
+
+    monkeypatch.setattr(_linear, "_reference_linear_reconstruction", fail_reference)
+    observed = _linear.evaluate_linear_reconstruction(
+        data,
+        selected_indices=(0, 2, 4),
+        labels=labels,
+    )
+
+    assert observed["jackknife"]["n_replicates"] == data.shape[0]
+
+
+def test_rank_deficient_design_falls_back_to_reference(monkeypatch):
+    rng = np.random.default_rng(911)
+    source = rng.normal(size=30)
+    target = 2.0 * source + rng.normal(scale=0.1, size=30)
+    data = np.column_stack((source, source, target))
+    labels = ("source", "duplicate", "target")
+    sentinel = {"fallback": True}
+
+    def reference(*_args, **_kwargs):
+        return sentinel
+
+    monkeypatch.setattr(_linear, "_reference_linear_reconstruction", reference)
+    observed = _linear.evaluate_linear_reconstruction(
+        data,
+        selected_indices=(0, 1),
+        labels=labels,
+    )
+
+    assert observed is sentinel


### PR DESCRIPTION
## Summary

This PR resumes the Case 3 performance work without narrowing scientific scope.

- preserves evaluation of all 625 tied MISs in Case 3;
- replaces repeated delete-one QR refits in the regular linear jackknife path with exact OLS case-deletion identities derived from one full-data QR factorization;
- retains the established implementation as an authoritative fallback for rank-deficient or numerically delicate designs;
- adds regression tests comparing the accelerated and reference implementations under the project's versioned numerical tolerance;
- does not change ranking, candidate-selection semantics, PRESS/LOO definitions, or jackknife definitions.

## Local numerical check

On Case-3-shaped N=300, M=20 data, the accelerated linear path evaluated all 625 candidate selections in about 4 s versus a ~59 s projection for the current implementation in the same environment (~15x). Random-data equivalence checks differed by at most ~1e-15, below the project gate tolerance of 1e-12.

This addresses the substantive work originally described in #5, which was closed as resolved by #6 even though #6 itself identified full-candidate evaluation performance as follow-up work.