### PR TITLE
R5.2 Formalize the 13 diagnostic scenarios

### DIFF
--- a/misda/benchmarks/__init__.py
+++ b/misda/benchmarks/__init__.py
@@ -1,8 +1,8 @@
 """
 misda.benchmarks — MISDA Benchmark Suite and Problem Generators.
 
-Exposes canonical structural cases, synthetic MOP problem generators, DTLZ benchmarks,
-and evaluation summary utilities.
+Exposes the unified controlled diagnostic catalogue, historical generator names,
+classical DTLZ generators, and evaluation summary utilities.
 """
 
 from .cases import (
@@ -26,6 +26,11 @@ from .mop import (
     generate_dtlz2,
     generate_dtlz5,
 )
+from .diagnostics import (
+    DIAGNOSTIC_BY_ID,
+    DIAGNOSTIC_SCENARIOS,
+    DiagnosticScenario,
+)
 from .comparative import (
     COMMON_RECONSTRUCTION_METRIC,
     global_standardized_reconstruction_r2,
@@ -44,6 +49,9 @@ from ..benchmark import (
 )
 
 __all__ = [
+    "DiagnosticScenario",
+    "DIAGNOSTIC_SCENARIOS",
+    "DIAGNOSTIC_BY_ID",
     "CANONICAL_CASES",
     "MOP_CASES",
     "make_case1_independence",

--- a/misda/benchmarks/diagnostics.py
+++ b/misda/benchmarks/diagnostics.py
@@ -1,0 +1,231 @@
+"""Controlled diagnostic scenario specifications for MISDA.
+
+The historical ``Case``/``MOP`` split is retained only in generator names while
+R5 migrates the implementation.  This module provides the single conceptual
+catalogue: each scenario declares its generating variables, clean problem map,
+observation model, truth dimensions, structural-unit sizes, and diagnostic tags.
+
+No truth in this catalogue is inferred from observed data or MISDA output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from .cases import (
+    make_case1_independence,
+    make_case2_total_redundancy,
+    make_case3_block_structure,
+    make_case4_two_big_blocks,
+    make_case5_chain_structure,
+    make_case6_mixed_structure,
+    make_case7_pure_conflict_groups,
+)
+from .mop import (
+    mopA_monotonic_redundancy,
+    mopB_tradeoff_with_redundancies,
+    mopC_latent_blocks_4x5,
+    mopD_pure_conflict_groups,
+    mopE_partial_redundancy_noisy,
+    mopF_regime_switching,
+)
+
+
+@dataclass(frozen=True)
+class DiagnosticScenario:
+    """Scientific specification for one controlled diagnostic problem."""
+
+    id: str
+    historical_name: str
+    generator: Callable
+    variables: tuple[str, ...]
+    clean_map: str
+    observation: str
+    latent_expected: int
+    structural_expected: int
+    unit_sizes: tuple[int, ...]
+    tags: frozenset[str]
+
+    def validate_legacy_contract(self, *, N: int = 32, seed: int = 123) -> None:
+        """Check that the legacy generator agrees with the declared problem truth."""
+        frame, truth = self.generator(N=N, seed=seed)
+        if frame.shape[1] != sum(self.unit_sizes):
+            raise AssertionError(
+                f"{self.id}: objective count does not match declared unit sizes"
+            )
+        if truth["latent_expected"] != self.latent_expected:
+            raise AssertionError(f"{self.id}: latent truth mismatch")
+        if truth["structural_expected"] != self.structural_expected:
+            raise AssertionError(f"{self.id}: structural truth mismatch")
+        observed_sizes = tuple(len(block) for block in truth["blocks_expected"])
+        if observed_sizes != self.unit_sizes:
+            raise AssertionError(f"{self.id}: structural-unit declaration mismatch")
+
+
+DIAGNOSTIC_SCENARIOS = (
+    DiagnosticScenario(
+        id="independence",
+        historical_name="Case 1 - Total independence",
+        generator=make_case1_independence,
+        variables=tuple(f"x{i}" for i in range(1, 21)),
+        clean_map="f_i = x_i for i=1..20",
+        observation="identity",
+        latent_expected=20,
+        structural_expected=20,
+        unit_sizes=(1,) * 20,
+        tags=frozenset({"independence", "linear"}),
+    ),
+    DiagnosticScenario(
+        id="total_redundancy",
+        historical_name="Case 2 - Total redundancy",
+        generator=make_case2_total_redundancy,
+        variables=("x",),
+        clean_map="20 copies of x",
+        observation="legacy additive Gaussian perturbation on each copy",
+        latent_expected=1,
+        structural_expected=1,
+        unit_sizes=(20,),
+        tags=frozenset({"total_redundancy", "linear", "noisy_observation"}),
+    ),
+    DiagnosticScenario(
+        id="blocks_4x5",
+        historical_name="Case 3 - Blocks (4 x 5)",
+        generator=make_case3_block_structure,
+        variables=("x1", "x2", "x3", "x4"),
+        clean_map="five copies of each independent factor x1..x4",
+        observation="legacy additive Gaussian perturbation on each copy",
+        latent_expected=4,
+        structural_expected=4,
+        unit_sizes=(5, 5, 5, 5),
+        tags=frozenset({"block_redundancy", "linear", "noisy_observation"}),
+    ),
+    DiagnosticScenario(
+        id="blocks_2x10",
+        historical_name="Case 4 - Blocks (2 x 10)",
+        generator=make_case4_two_big_blocks,
+        variables=("x1", "x2"),
+        clean_map="ten copies of each independent factor x1,x2",
+        observation="legacy additive Gaussian perturbation on each copy",
+        latent_expected=2,
+        structural_expected=2,
+        unit_sizes=(10, 10),
+        tags=frozenset({"block_redundancy", "linear", "noisy_observation"}),
+    ),
+    DiagnosticScenario(
+        id="transitive_chain",
+        historical_name="Case 5 - Chain",
+        generator=make_case5_chain_structure,
+        variables=tuple(f"x{i}" for i in range(1, 21)),
+        clean_map=(
+            "f1=x1; fj=x1+0.2*x2+...+0.2*xj for j=2..20 "
+            "(triangular cumulative map)"
+        ),
+        observation="identity; innovations are generating degrees of freedom, not noise",
+        latent_expected=20,
+        structural_expected=20,
+        unit_sizes=(20,),
+        tags=frozenset({"transitive_chaining", "linear", "known_failure_mode"}),
+    ),
+    DiagnosticScenario(
+        id="mixed_independent_and_blocks",
+        historical_name="Case 6 - Mixed (indep + latents)",
+        generator=make_case6_mixed_structure,
+        variables=tuple(f"x{i}" for i in range(1, 13)),
+        clean_map="10 independent objectives plus two factors replicated five times each",
+        observation="legacy additive Gaussian perturbation on replicated factors",
+        latent_expected=12,
+        structural_expected=12,
+        unit_sizes=(1,) * 10 + (5, 5),
+        tags=frozenset({"mixed_structure", "block_redundancy", "noisy_observation"}),
+    ),
+    DiagnosticScenario(
+        id="antagonistic_linear_groups",
+        historical_name="Case 7 - Structural conflict (anti-corr) 2-groups",
+        generator=make_case7_pure_conflict_groups,
+        variables=("x",),
+        clean_map="10 copies of x and 10 copies of -x",
+        observation="legacy additive Gaussian perturbation on each objective",
+        latent_expected=1,
+        structural_expected=2,
+        unit_sizes=(10, 10),
+        tags=frozenset({"antagonistic_conflict", "linear", "noisy_observation"}),
+    ),
+    DiagnosticScenario(
+        id="monotonic_redundancy",
+        historical_name="MOP-A — Monotonic redundancy",
+        generator=mopA_monotonic_redundancy,
+        variables=("x",),
+        clean_map="20 monotone nonlinear transformations of x",
+        observation="optional additive Gaussian perturbation after each transform",
+        latent_expected=1,
+        structural_expected=1,
+        unit_sizes=(20,),
+        tags=frozenset({"total_redundancy", "nonlinear", "monotonic"}),
+    ),
+    DiagnosticScenario(
+        id="tradeoff_redundancies",
+        historical_name="MOP-B — Trade-off + redundancies",
+        generator=mopB_tradeoff_with_redundancies,
+        variables=("a", "b"),
+        clean_map="cost C(a,b), consumption E(a,b), and performance Q(a,b) families",
+        observation="legacy small perturbation on selected family replicas",
+        latent_expected=2,
+        structural_expected=2,
+        unit_sizes=(7, 7, 6),
+        tags=frozenset({"tradeoff", "nonlinear", "family_redundancy"}),
+    ),
+    DiagnosticScenario(
+        id="nonlinear_blocks_4x5",
+        historical_name="MOP-C — Latent blocks",
+        generator=mopC_latent_blocks_4x5,
+        variables=("u", "v", "w", "z"),
+        clean_map="five nonlinear transforms of each independent factor u,v,w,z",
+        observation="legacy perturbation on one w-family replica",
+        latent_expected=4,
+        structural_expected=4,
+        unit_sizes=(5, 5, 5, 5),
+        tags=frozenset({"block_redundancy", "nonlinear"}),
+    ),
+    DiagnosticScenario(
+        id="antagonistic_nonlinear_groups",
+        historical_name="MOP-D — Structural conflict (anti-corr) 2-groups",
+        generator=mopD_pure_conflict_groups,
+        variables=("x",),
+        clean_map="10 monotone transforms of x and 10 of 1-x",
+        observation="optional additive Gaussian perturbation after each transform",
+        latent_expected=1,
+        structural_expected=2,
+        unit_sizes=(10, 10),
+        tags=frozenset({"antagonistic_conflict", "nonlinear", "tradeoff"}),
+    ),
+    DiagnosticScenario(
+        id="overlapping_factors",
+        historical_name="MOP-E — Partial redundancy + noise",
+        generator=mopE_partial_redundancy_noisy,
+        variables=("a", "b"),
+        clean_map="families on a, b, and the overlapping compound a+b",
+        observation="legacy perturbation on selected a-family replicas",
+        latent_expected=2,
+        structural_expected=2,
+        unit_sizes=(10, 4, 6),
+        tags=frozenset({"overlapping_factors", "nonlinear", "partial_redundancy"}),
+    ),
+    DiagnosticScenario(
+        id="regime_switching",
+        historical_name="MOP-F — Regimes (mixture, M=20)",
+        generator=mopF_regime_switching,
+        variables=("a", "b"),
+        clean_map="nonlinear transforms of regime mixture L(a,b) plus transforms of b",
+        observation="optional additive Gaussian perturbation after clean transforms",
+        latent_expected=2,
+        structural_expected=2,
+        unit_sizes=(10, 10),
+        tags=frozenset({"regime_switching", "nonlinear", "known_failure_mode"}),
+    ),
+)
+
+DIAGNOSTIC_BY_ID = {scenario.id: scenario for scenario in DIAGNOSTIC_SCENARIOS}
+
+if len(DIAGNOSTIC_BY_ID) != len(DIAGNOSTIC_SCENARIOS):
+    raise RuntimeError("Diagnostic scenario ids must be unique")

--- a/misda/benchmarks/diagnostics.py
+++ b/misda/benchmarks/diagnostics.py
@@ -1,9 +1,15 @@
 """Controlled diagnostic scenario specifications for MISDA.
 
 The historical ``Case``/``MOP`` split is retained only in generator names while
-R5 migrates the implementation.  This module provides the single conceptual
-catalogue: each scenario declares its generating variables, clean problem map,
-observation model, truth dimensions, structural-unit sizes, and diagnostic tags.
+R5 migrates the implementation. This module provides one conceptual catalogue:
+each scenario declares its generating variables, clean problem map, observation
+model, truth dimensions, legacy generating-family partition, and diagnostic
+tags.
+
+Generating families are descriptive groupings and are deliberately not used to
+infer structural dimension. Case 5 (one cumulative family but structural truth
+20) and MOP-B (three functional families but structural truth 2) make this
+distinction explicit.
 
 No truth in this catalogue is inferred from observed data or MISDA output.
 """
@@ -44,23 +50,23 @@ class DiagnosticScenario:
     observation: str
     latent_expected: int
     structural_expected: int
-    unit_sizes: tuple[int, ...]
+    family_sizes: tuple[int, ...]
     tags: frozenset[str]
 
     def validate_legacy_contract(self, *, N: int = 32, seed: int = 123) -> None:
-        """Check that the legacy generator agrees with the declared problem truth."""
+        """Check legacy output against the explicit scenario declaration."""
         frame, truth = self.generator(N=N, seed=seed)
-        if frame.shape[1] != sum(self.unit_sizes):
+        if frame.shape[1] != sum(self.family_sizes):
             raise AssertionError(
-                f"{self.id}: objective count does not match declared unit sizes"
+                f"{self.id}: objective count does not match generating families"
             )
         if truth["latent_expected"] != self.latent_expected:
             raise AssertionError(f"{self.id}: latent truth mismatch")
         if truth["structural_expected"] != self.structural_expected:
             raise AssertionError(f"{self.id}: structural truth mismatch")
         observed_sizes = tuple(len(block) for block in truth["blocks_expected"])
-        if observed_sizes != self.unit_sizes:
-            raise AssertionError(f"{self.id}: structural-unit declaration mismatch")
+        if observed_sizes != self.family_sizes:
+            raise AssertionError(f"{self.id}: generating-family declaration mismatch")
 
 
 DIAGNOSTIC_SCENARIOS = (
@@ -73,7 +79,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="identity",
         latent_expected=20,
         structural_expected=20,
-        unit_sizes=(1,) * 20,
+        family_sizes=(1,) * 20,
         tags=frozenset({"independence", "linear"}),
     ),
     DiagnosticScenario(
@@ -85,7 +91,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="legacy additive Gaussian perturbation on each copy",
         latent_expected=1,
         structural_expected=1,
-        unit_sizes=(20,),
+        family_sizes=(20,),
         tags=frozenset({"total_redundancy", "linear", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -97,7 +103,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="legacy additive Gaussian perturbation on each copy",
         latent_expected=4,
         structural_expected=4,
-        unit_sizes=(5, 5, 5, 5),
+        family_sizes=(5, 5, 5, 5),
         tags=frozenset({"block_redundancy", "linear", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -109,7 +115,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="legacy additive Gaussian perturbation on each copy",
         latent_expected=2,
         structural_expected=2,
-        unit_sizes=(10, 10),
+        family_sizes=(10, 10),
         tags=frozenset({"block_redundancy", "linear", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -124,7 +130,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="identity; innovations are generating degrees of freedom, not noise",
         latent_expected=20,
         structural_expected=20,
-        unit_sizes=(20,),
+        family_sizes=(20,),
         tags=frozenset({"transitive_chaining", "linear", "known_failure_mode"}),
     ),
     DiagnosticScenario(
@@ -136,7 +142,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="legacy additive Gaussian perturbation on replicated factors",
         latent_expected=12,
         structural_expected=12,
-        unit_sizes=(1,) * 10 + (5, 5),
+        family_sizes=(1,) * 10 + (5, 5),
         tags=frozenset({"mixed_structure", "block_redundancy", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -148,7 +154,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="legacy additive Gaussian perturbation on each objective",
         latent_expected=1,
         structural_expected=2,
-        unit_sizes=(10, 10),
+        family_sizes=(10, 10),
         tags=frozenset({"antagonistic_conflict", "linear", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -160,7 +166,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="optional additive Gaussian perturbation after each transform",
         latent_expected=1,
         structural_expected=1,
-        unit_sizes=(20,),
+        family_sizes=(20,),
         tags=frozenset({"total_redundancy", "nonlinear", "monotonic"}),
     ),
     DiagnosticScenario(
@@ -172,7 +178,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="legacy small perturbation on selected family replicas",
         latent_expected=2,
         structural_expected=2,
-        unit_sizes=(7, 7, 6),
+        family_sizes=(7, 7, 6),
         tags=frozenset({"tradeoff", "nonlinear", "family_redundancy"}),
     ),
     DiagnosticScenario(
@@ -184,7 +190,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="legacy perturbation on one w-family replica",
         latent_expected=4,
         structural_expected=4,
-        unit_sizes=(5, 5, 5, 5),
+        family_sizes=(5, 5, 5, 5),
         tags=frozenset({"block_redundancy", "nonlinear"}),
     ),
     DiagnosticScenario(
@@ -196,7 +202,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="optional additive Gaussian perturbation after each transform",
         latent_expected=1,
         structural_expected=2,
-        unit_sizes=(10, 10),
+        family_sizes=(10, 10),
         tags=frozenset({"antagonistic_conflict", "nonlinear", "tradeoff"}),
     ),
     DiagnosticScenario(
@@ -208,7 +214,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="legacy perturbation on selected a-family replicas",
         latent_expected=2,
         structural_expected=2,
-        unit_sizes=(10, 4, 6),
+        family_sizes=(10, 4, 6),
         tags=frozenset({"overlapping_factors", "nonlinear", "partial_redundancy"}),
     ),
     DiagnosticScenario(
@@ -220,7 +226,7 @@ DIAGNOSTIC_SCENARIOS = (
         observation="optional additive Gaussian perturbation after clean transforms",
         latent_expected=2,
         structural_expected=2,
-        unit_sizes=(10, 10),
+        family_sizes=(10, 10),
         tags=frozenset({"regime_switching", "nonlinear", "known_failure_mode"}),
     ),
 )

--- a/tests/test_diagnostic_scenarios.py
+++ b/tests/test_diagnostic_scenarios.py
@@ -1,0 +1,45 @@
+"""Scientific contract checks for the unified diagnostic catalogue."""
+
+import pytest
+
+from misda.benchmarks import DIAGNOSTIC_BY_ID, DIAGNOSTIC_SCENARIOS
+
+
+def test_diagnostic_catalogue_contains_thirteen_unique_scenarios():
+    assert len(DIAGNOSTIC_SCENARIOS) == 13
+    assert len(DIAGNOSTIC_BY_ID) == 13
+    assert tuple(DIAGNOSTIC_BY_ID) == tuple(s.id for s in DIAGNOSTIC_SCENARIOS)
+
+
+@pytest.mark.parametrize("scenario", DIAGNOSTIC_SCENARIOS, ids=lambda s: s.id)
+def test_diagnostic_spec_agrees_with_legacy_generator(scenario):
+    assert scenario.variables
+    assert scenario.clean_map
+    assert scenario.observation
+    assert scenario.tags
+    assert scenario.latent_expected >= 1
+    assert scenario.structural_expected >= 1
+    assert sum(scenario.family_sizes) == 20
+    scenario.validate_legacy_contract(N=32, seed=123)
+
+
+def test_generating_families_are_not_used_as_structural_dimension():
+    chain = DIAGNOSTIC_BY_ID["transitive_chain"]
+    tradeoff = DIAGNOSTIC_BY_ID["tradeoff_redundancies"]
+
+    # One cumulative generating family contains 20 independent innovations.
+    assert chain.family_sizes == (20,)
+    assert chain.structural_expected == 20
+
+    # Three functional families are driven by a 2D structural truth.
+    assert tradeoff.family_sizes == (7, 7, 6)
+    assert tradeoff.structural_expected == 2
+
+
+def test_case5_innovations_are_declared_as_structure_not_observation_noise():
+    chain = DIAGNOSTIC_BY_ID["transitive_chain"]
+    assert "identity" in chain.observation
+    assert "not noise" in chain.observation
+    assert len(chain.variables) == 20
+    assert chain.latent_expected == 20
+    assert chain.structural_expected == 20


### PR DESCRIPTION
Closes #23.

## Summary
- introduces one `DiagnosticScenario` catalogue for all 13 controlled scenarios;
- makes generating variables, clean-map semantics, observation semantics, truth dimensions and diagnostic tags explicit;
- retains historical Case/MOP generator names only as implementation provenance;
- explicitly separates generating-family partitions from structural dimension (notably Case 5 and MOP-B);
- validates every specification against the unchanged legacy generator contract;
- makes no MISDA algorithm or dataset change.

## Integration rule
Rebase-merge only after the full acceptance gate succeeds.