### PR TITLE
R5.4 Define Pareto truth from clean diagnostic objectives

### DIFF
--- a/misda/benchmarks/__init__.py
+++ b/misda/benchmarks/__init__.py
@@ -2,8 +2,8 @@
 misda.benchmarks — MISDA Benchmark Suite and Problem Generators.
 
 Exposes the unified controlled diagnostic catalogue and executable X -> Z -> Y
-problems, historical generator names, classical DTLZ generators, and evaluation
-summary utilities.
+problems, clean ground-truth helpers, historical generator names, classical DTLZ
+generators, and evaluation summary utilities.
 """
 
 from .cases import (
@@ -38,6 +38,7 @@ from .problems import (
     DiagnosticDataset,
     DiagnosticProblem,
 )
+from .truth import diagnostic_truth, sampled_pareto_indices
 from .comparative import (
     COMMON_RECONSTRUCTION_METRIC,
     global_standardized_reconstruction_r2,
@@ -63,6 +64,8 @@ __all__ = [
     "DiagnosticDataset",
     "PROBLEMS",
     "PROBLEM_BY_ID",
+    "diagnostic_truth",
+    "sampled_pareto_indices",
     "CANONICAL_CASES",
     "MOP_CASES",
     "make_case1_independence",

--- a/misda/benchmarks/truth.py
+++ b/misda/benchmarks/truth.py
@@ -1,0 +1,43 @@
+"""Ground-truth helpers for controlled diagnostic problems.
+
+All Pareto truth in the R5 diagnostic architecture is defined on the sampled
+clean objective matrix Z, never on the observed matrix Y.  Objectives are
+minimized. Exact duplicate objective vectors are all retained as nondominated
+whenever their common vector is nondominated, preserving sample-row identity.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .._pareto import get_nondominated_mask_minimize
+
+
+def sampled_pareto_indices(Z: pd.DataFrame | np.ndarray) -> list[int]:
+    """Return sample indices nondominated in the clean minimization matrix Z."""
+    values = Z.to_numpy(dtype=float) if isinstance(Z, pd.DataFrame) else np.asarray(Z, dtype=float)
+    if values.ndim != 2 or values.shape[0] == 0 or values.shape[1] == 0:
+        raise ValueError("Z must be a non-empty two-dimensional objective matrix")
+    mask = get_nondominated_mask_minimize(values)
+    return [int(index) for index in np.flatnonzero(mask)]
+
+
+def diagnostic_truth(problem, Z: pd.DataFrame) -> dict:
+    """Build truth from the theoretical problem declaration and its clean Z."""
+    scenario = problem.scenario
+    families: list[list[str]] = []
+    start = 1
+    for size in scenario.family_sizes:
+        families.append([f"f{i}" for i in range(start, start + size)])
+        start += size
+
+    return {
+        "name": scenario.historical_name,
+        "problem_id": problem.id,
+        "latent_expected": scenario.latent_expected,
+        "structural_expected": scenario.structural_expected,
+        "blocks_expected": families,
+        "pareto_expected": sampled_pareto_indices(Z),
+        "tags": sorted(scenario.tags),
+    }

--- a/tests/test_diagnostic_truth.py
+++ b/tests/test_diagnostic_truth.py
@@ -1,0 +1,70 @@
+"""Ground-truth checks for sampled clean diagnostic objectives."""
+
+import numpy as np
+
+from misda.benchmarks import (
+    PROBLEM_BY_ID,
+    PROBLEMS,
+    diagnostic_truth,
+    sampled_pareto_indices,
+)
+
+
+def test_pareto_truth_is_available_for_every_clean_diagnostic_problem():
+    for problem in PROBLEMS:
+        dataset = problem.generate(N=48, seed=123, sigma=0.0)
+        truth = diagnostic_truth(problem, dataset.Z)
+        assert truth["pareto_expected"]
+        assert all(0 <= index < 48 for index in truth["pareto_expected"])
+
+
+def test_pareto_truth_does_not_change_when_observation_noise_changes():
+    problem = PROBLEM_BY_ID["monotonic_redundancy"]
+    clean = problem.generate(N=64, seed=123, sigma=0.0, observation_seed=1)
+    noisy = problem.generate(N=64, seed=123, sigma=0.25, observation_seed=999)
+
+    np.testing.assert_array_equal(clean.Z.to_numpy(), noisy.Z.to_numpy())
+    assert diagnostic_truth(problem, clean.Z)["pareto_expected"] == diagnostic_truth(
+        problem, noisy.Z
+    )["pareto_expected"]
+    assert not np.array_equal(clean.Y.to_numpy(), noisy.Y.to_numpy())
+
+
+def test_mop_a_clean_truth_is_argmin_x_even_when_y_is_noisy():
+    problem = PROBLEM_BY_ID["monotonic_redundancy"]
+    dataset = problem.generate(N=80, seed=123, sigma=0.20, observation_seed=456)
+    expected = [int(np.argmin(dataset.X["x"].to_numpy()))]
+
+    assert diagnostic_truth(problem, dataset.Z)["pareto_expected"] == expected
+
+
+def test_mop_d_clean_truth_contains_every_sample_even_when_y_is_noisy():
+    problem = PROBLEM_BY_ID["antagonistic_nonlinear_groups"]
+    dataset = problem.generate(N=80, seed=123, sigma=0.20, observation_seed=456)
+
+    assert diagnostic_truth(problem, dataset.Z)["pareto_expected"] == list(range(80))
+
+
+def test_duplicate_nondominated_rows_preserve_all_sample_indices():
+    Z = np.array(
+        [
+            [0.0, 1.0],
+            [0.0, 1.0],
+            [1.0, 0.0],
+            [2.0, 2.0],
+        ]
+    )
+
+    assert sampled_pareto_indices(Z) == [0, 1, 2]
+
+
+def test_pareto_truth_is_based_on_z_not_observed_y():
+    problem = PROBLEM_BY_ID["monotonic_redundancy"]
+    dataset = problem.generate(N=96, seed=321, sigma=1.0, observation_seed=777)
+    clean_truth = diagnostic_truth(problem, dataset.Z)["pareto_expected"]
+    observed_front = sampled_pareto_indices(dataset.Y)
+
+    # Large observation noise can alter the observed front; it must not alter truth.
+    assert clean_truth == [int(np.argmin(dataset.X["x"].to_numpy()))]
+    assert diagnostic_truth(problem, dataset.Z)["pareto_expected"] == clean_truth
+    assert isinstance(observed_front, list)


### PR DESCRIPTION
Closes #25.

## Summary
- defines sampled minimization truth as `pareto_expected = ND(Z)`;
- computes Pareto truth from the clean objective matrix only, never from observed `Y`;
- preserves every duplicate row index when a duplicated objective vector is nondominated;
- exposes the rule for all 13 controlled diagnostic problems;
- adds explicit noisy-observation tests for MOP-A (argmin x) and MOP-D (all sampled rows);
- verifies that changing sigma or the observation seed changes `Y` but not clean Pareto truth.

The historical generators remain regression fixtures in this migration stage; their old noise-dependent truth declarations no longer define truth for the new diagnostic architecture and will be retired from the canonical diagnostic path in R5.5.

No MISDA algorithm code is changed.

## Integration rule
Rebase-merge only after the full acceptance gate succeeds.