### PR TITLE
Fix diagnostic truth semantics for families and structural units

### DIFF
--- a/docs/adr/0013-benchmark-and-validation-contract.md
+++ b/docs/adr/0013-benchmark-and-validation-contract.md
@@ -5,23 +5,26 @@
 
 ## Context
 
-MISDA needs scientific validation against synthetic or otherwise declared truth without contaminating the inference path. Benchmark declarations may describe expected dimensions, structural/generating units, connected components, graphs, Pareto sets, and known diagnostic-backed limitations.
+MISDA needs scientific validation against synthetic or otherwise declared truth without contaminating the inference path. Benchmark declarations may describe expected dimensions, generating families, structural units, connected components, graphs, Pareto sets, and known diagnostic-backed limitations.
 
 ## Decision
 
 Benchmarking is strictly downstream of discovery/evaluation. It compares declared truth with already computed outputs and never feeds truth back into the method.
 
-The benchmark may compare, when declared:
+The benchmark may compare or report, when declared:
 
 - latent dimension;
 - structural dimension;
-- structural/generating blocks;
-- connected components;
+- generating families (`families_expected`);
+- structural units (`blocks_expected`);
+- connected components (`components_expected`);
 - graph structure;
 - Pareto indices/evidence;
 - other explicitly declared reference quantities.
 
-Dimension declarations and component declarations are distinct. `blocks_expected` and `components_expected` are also distinct and must not be inferred from one another.
+Generating families, structural units, and connected components are distinct concepts. None may be inferred from another merely because their partitions happen to coincide in a particular diagnostic. In particular, `families_expected` describes the theoretical generating organization, `blocks_expected` declares an unambiguous structural-unit partition when one exists, and `components_expected` declares expected graph connectivity when independently justified.
+
+Dimension declarations are likewise distinct from all three partitions. A generating family count, structural-unit count, or component count must not be substituted for latent or structural dimension.
 
 Dimension accuracy includes absolute error, relative error where defined, and exact-match status.
 
@@ -46,6 +49,7 @@ Strict acceptance fails on unexpected declaration mismatches and must identify c
 ## Invariants
 
 - benchmark truth is read only by benchmark code;
+- generating families, structural units, connected components, and dimensions remain separately declared concepts;
 - expected dimension is never treated as expected component count;
 - undeclared truth yields an explicit N/A state;
 - known-failure exemptions are field-specific and diagnostic-backed;
@@ -53,12 +57,12 @@ Strict acceptance fails on unexpected declaration mismatches and must identify c
 
 ## Current implementation
 
-The benchmark infrastructure consumes `MISSet`/`Ranking` outputs and stored evidence. The acceptance workflow runs the canonical benchmark in strict mode. Current project acceptance also exercises the static test suite, relevant slow tests, notebooks, the scientific battery, and comparative experiments.
+The benchmark infrastructure consumes `MISSet`/`Ranking` outputs and stored evidence. Controlled diagnostic truth reports generating families for every scenario, structural units only where the diagnostic specification provides an unambiguous partition, and graph components only when explicitly declared. The acceptance workflow runs the canonical benchmark in strict mode. Current project acceptance also exercises the static test suite, relevant slow tests, notebooks, the scientific battery, and comparative experiments.
 
 ## Forbidden shortcuts / regression risks
 
-Do not tune discovery from expected values, silently infer missing declarations, globally waive a failing case because one field is known-problematic, or let quick-mode outcomes replace canonical scientific validation.
+Do not tune discovery from expected values, silently infer missing declarations, treat generating families as structural units, infer components from either family or structural-unit partitions, globally waive a failing case because one field is known-problematic, or let quick-mode outcomes replace canonical scientific validation.
 
 ## Verification
 
-Benchmark tests should deliberately vary declarations while keeping method outputs fixed, exercise N/A behavior, expected-vs-unexpected mismatch classification, and confirm strict-mode failure semantics.
+Benchmark tests should deliberately vary declarations while keeping method outputs fixed, exercise N/A behavior, distinguish generating-family/structural-unit/component semantics (especially Case 5 and MOP-B), exercise expected-vs-unexpected mismatch classification, and confirm strict-mode failure semantics.

--- a/misda/benchmark.py
+++ b/misda/benchmark.py
@@ -348,16 +348,20 @@ class BenchmarkResult:
         analysis = self.result.analysis
         ranking = self.result.structural_ranking
         preferred = ranking.selected
+        families_expected = _normalize_label_blocks(
+            self.truth.get("families_expected"), "families_expected"
+        )
         lines = [f"MISDA benchmark report: {self.name or 'Untitled'}"]
         lines.append("=" * 72)
         lines.append("Declaration")
-        lines.append(f"  Feature        : {self.feature or 'N/A'}")
-        lines.append(f"  Intuition      : {self.intuition or 'N/A'}")
-        lines.append(f"  Expected graph : {self.graph_expected or 'N/A'}")
-        lines.append(f"  Expected blocks: {_format_blocks(self.blocks_expected)}")
-        lines.append(f"  Expected comps.: {_format_blocks(self.components_expected)}")
+        lines.append(f"  Feature             : {self.feature or 'N/A'}")
+        lines.append(f"  Intuition           : {self.intuition or 'N/A'}")
+        lines.append(f"  Expected graph      : {self.graph_expected or 'N/A'}")
+        lines.append(f"  Generating families : {_format_blocks(families_expected)}")
+        lines.append(f"  Structural units    : {_format_blocks(self.blocks_expected)}")
+        lines.append(f"  Expected components : {_format_blocks(self.components_expected)}")
         if self.notes:
-            lines.append(f"  Notes          : {self.notes}")
+            lines.append(f"  Notes               : {self.notes}")
 
         lines.append("Observed analysis")
         lines.append(

--- a/misda/benchmarks/diagnostics.py
+++ b/misda/benchmarks/diagnostics.py
@@ -51,8 +51,8 @@ class DiagnosticScenario:
     latent_expected: int
     structural_expected: int
     family_sizes: tuple[int, ...]
-    structural_unit_sizes: tuple[int, ...] | None
     tags: frozenset[str]
+    structural_unit_sizes: tuple[int, ...] | None = None
 
     def validate_legacy_contract(self, *, N: int = 32, seed: int = 123) -> None:
         """Check legacy output against the explicit scenario declaration."""

--- a/misda/benchmarks/diagnostics.py
+++ b/misda/benchmarks/diagnostics.py
@@ -3,13 +3,13 @@
 The historical ``Case``/``MOP`` split is retained only in generator names while
 R5 migrates the implementation. This module provides one conceptual catalogue:
 each scenario declares its generating variables, clean problem map, observation
-model, truth dimensions, legacy generating-family partition, and diagnostic
-tags.
+model, truth dimensions, legacy generating-family partition, optional structural
+units, and diagnostic tags.
 
 Generating families are descriptive groupings and are deliberately not used to
-infer structural dimension. Case 5 (one cumulative family but structural truth
-20) and MOP-B (three functional families but structural truth 2) make this
-distinction explicit.
+infer structural dimension or structural units. Case 5 (one cumulative family
+but 20 structural units) and MOP-B (three functional families but no unambiguous
+structural partition) make this distinction explicit.
 
 No truth in this catalogue is inferred from observed data or MISDA output.
 """
@@ -51,6 +51,7 @@ class DiagnosticScenario:
     latent_expected: int
     structural_expected: int
     family_sizes: tuple[int, ...]
+    structural_unit_sizes: tuple[int, ...] | None
     tags: frozenset[str]
 
     def validate_legacy_contract(self, *, N: int = 32, seed: int = 123) -> None:
@@ -67,6 +68,15 @@ class DiagnosticScenario:
         observed_sizes = tuple(len(block) for block in truth["blocks_expected"])
         if observed_sizes != self.family_sizes:
             raise AssertionError(f"{self.id}: generating-family declaration mismatch")
+        if self.structural_unit_sizes is not None:
+            if sum(self.structural_unit_sizes) != frame.shape[1]:
+                raise AssertionError(
+                    f"{self.id}: structural units must partition all objectives"
+                )
+            if len(self.structural_unit_sizes) != self.structural_expected:
+                raise AssertionError(
+                    f"{self.id}: structural-unit count must match structural truth"
+                )
 
 
 DIAGNOSTIC_SCENARIOS = (
@@ -80,6 +90,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=20,
         structural_expected=20,
         family_sizes=(1,) * 20,
+        structural_unit_sizes=(1,) * 20,
         tags=frozenset({"independence", "linear"}),
     ),
     DiagnosticScenario(
@@ -92,6 +103,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=1,
         structural_expected=1,
         family_sizes=(20,),
+        structural_unit_sizes=(20,),
         tags=frozenset({"total_redundancy", "linear", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -104,6 +116,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=4,
         structural_expected=4,
         family_sizes=(5, 5, 5, 5),
+        structural_unit_sizes=(5, 5, 5, 5),
         tags=frozenset({"block_redundancy", "linear", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -116,6 +129,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=2,
         structural_expected=2,
         family_sizes=(10, 10),
+        structural_unit_sizes=(10, 10),
         tags=frozenset({"block_redundancy", "linear", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -131,6 +145,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=20,
         structural_expected=20,
         family_sizes=(20,),
+        structural_unit_sizes=(1,) * 20,
         tags=frozenset({"transitive_chaining", "linear", "known_failure_mode"}),
     ),
     DiagnosticScenario(
@@ -143,6 +158,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=12,
         structural_expected=12,
         family_sizes=(1,) * 10 + (5, 5),
+        structural_unit_sizes=(1,) * 10 + (5, 5),
         tags=frozenset({"mixed_structure", "block_redundancy", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -155,6 +171,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=1,
         structural_expected=2,
         family_sizes=(10, 10),
+        structural_unit_sizes=(10, 10),
         tags=frozenset({"antagonistic_conflict", "linear", "noisy_observation"}),
     ),
     DiagnosticScenario(
@@ -167,6 +184,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=1,
         structural_expected=1,
         family_sizes=(20,),
+        structural_unit_sizes=(20,),
         tags=frozenset({"total_redundancy", "nonlinear", "monotonic"}),
     ),
     DiagnosticScenario(
@@ -179,6 +197,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=2,
         structural_expected=2,
         family_sizes=(7, 7, 6),
+        structural_unit_sizes=None,
         tags=frozenset({"tradeoff", "nonlinear", "family_redundancy"}),
     ),
     DiagnosticScenario(
@@ -191,6 +210,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=4,
         structural_expected=4,
         family_sizes=(5, 5, 5, 5),
+        structural_unit_sizes=(5, 5, 5, 5),
         tags=frozenset({"block_redundancy", "nonlinear"}),
     ),
     DiagnosticScenario(
@@ -203,6 +223,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=1,
         structural_expected=2,
         family_sizes=(10, 10),
+        structural_unit_sizes=(10, 10),
         tags=frozenset({"antagonistic_conflict", "nonlinear", "tradeoff"}),
     ),
     DiagnosticScenario(
@@ -215,6 +236,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=2,
         structural_expected=2,
         family_sizes=(10, 4, 6),
+        structural_unit_sizes=None,
         tags=frozenset({"overlapping_factors", "nonlinear", "partial_redundancy"}),
     ),
     DiagnosticScenario(
@@ -227,6 +249,7 @@ DIAGNOSTIC_SCENARIOS = (
         latent_expected=2,
         structural_expected=2,
         family_sizes=(10, 10),
+        structural_unit_sizes=(10, 10),
         tags=frozenset({"regime_switching", "nonlinear", "known_failure_mode"}),
     ),
 )

--- a/misda/benchmarks/problems.py
+++ b/misda/benchmarks/problems.py
@@ -94,15 +94,20 @@ class DiagnosticProblem:
 
     def truth(self) -> dict:
         """Return generator truth; never inspect observed data or MISDA output."""
-        return {
+        truth = {
             "name": self.scenario.historical_name,
             "problem_id": self.id,
             "latent_expected": self.scenario.latent_expected,
             "structural_expected": self.scenario.structural_expected,
-            "blocks_expected": _family_names(self.scenario.family_sizes),
+            "families_expected": _family_names(self.scenario.family_sizes),
             "pareto_expected": None,
             "tags": sorted(self.scenario.tags),
         }
+        if self.scenario.structural_unit_sizes is not None:
+            truth["blocks_expected"] = _family_names(
+                self.scenario.structural_unit_sizes
+            )
+        return truth
 
     def observe(
         self,

--- a/misda/benchmarks/truth.py
+++ b/misda/benchmarks/truth.py
@@ -6,8 +6,9 @@ minimized. Exact duplicate objective vectors are all retained as nondominated
 whenever their common vector is nondominated, preserving sample-row identity.
 
 Generating families and structural units are separate declarations. Families
-describe how objectives are generated; structural units are declared only when
-the problem specification supplies an unambiguous structural partition.
+describe how objectives are generated; ``blocks_expected`` keeps its public
+benchmark meaning as structural units and is declared only when the problem
+specification supplies an unambiguous structural partition.
 """
 
 from __future__ import annotations
@@ -68,7 +69,5 @@ def diagnostic_truth(problem, Z: pd.DataFrame) -> dict:
         "expected_mismatches": dict(_EXPECTED_MISMATCHES.get(problem.id, {})),
     }
     if scenario.structural_unit_sizes is not None:
-        truth["structural_units_expected"] = _label_groups(
-            scenario.structural_unit_sizes
-        )
+        truth["blocks_expected"] = _label_groups(scenario.structural_unit_sizes)
     return truth

--- a/misda/benchmarks/truth.py
+++ b/misda/benchmarks/truth.py
@@ -4,6 +4,10 @@ All Pareto truth in the R5 diagnostic architecture is defined on the sampled
 clean objective matrix Z, never on the observed matrix Y. Objectives are
 minimized. Exact duplicate objective vectors are all retained as nondominated
 whenever their common vector is nondominated, preserving sample-row identity.
+
+Generating families and structural units are separate declarations. Families
+describe how objectives are generated; structural units are declared only when
+the problem specification supplies an unambiguous structural partition.
 """
 
 from __future__ import annotations
@@ -18,6 +22,7 @@ _EXPECTED_MISMATCHES = {
     "transitive_chain": {
         "latent_dimension": "TRANSITIVE_CHAINING",
         "structural_dimension": "TRANSITIVE_CHAINING",
+        "selected_structural_units": "TRANSITIVE_CHAINING",
     },
     "regime_switching": {
         "latent_dimension": "HIDDEN_SPECTRAL_STRUCTURE",
@@ -25,6 +30,15 @@ _EXPECTED_MISMATCHES = {
         "selected_structural_units": "HIDDEN_SPECTRAL_STRUCTURE",
     },
 }
+
+
+def _label_groups(sizes: tuple[int, ...]) -> list[list[str]]:
+    groups: list[list[str]] = []
+    start = 1
+    for size in sizes:
+        groups.append([f"f{i}" for i in range(start, start + size)])
+        start += size
+    return groups
 
 
 def sampled_pareto_indices(Z: pd.DataFrame | np.ndarray) -> list[int]:
@@ -43,19 +57,18 @@ def sampled_pareto_indices(Z: pd.DataFrame | np.ndarray) -> list[int]:
 def diagnostic_truth(problem, Z: pd.DataFrame) -> dict:
     """Build truth from the theoretical problem declaration and its clean Z."""
     scenario = problem.scenario
-    families: list[list[str]] = []
-    start = 1
-    for size in scenario.family_sizes:
-        families.append([f"f{i}" for i in range(start, start + size)])
-        start += size
-
-    return {
+    truth = {
         "name": scenario.historical_name,
         "problem_id": problem.id,
         "latent_expected": scenario.latent_expected,
         "structural_expected": scenario.structural_expected,
-        "blocks_expected": families,
+        "families_expected": _label_groups(scenario.family_sizes),
         "pareto_expected": sampled_pareto_indices(Z),
         "tags": sorted(scenario.tags),
         "expected_mismatches": dict(_EXPECTED_MISMATCHES.get(problem.id, {})),
     }
+    if scenario.structural_unit_sizes is not None:
+        truth["structural_units_expected"] = _label_groups(
+            scenario.structural_unit_sizes
+        )
+    return truth

--- a/tests/test_benchmark_report_evidence.py
+++ b/tests/test_benchmark_report_evidence.py
@@ -34,6 +34,23 @@ def test_report_exposes_observed_evidence_without_external_metric_truth():
     assert "N/A — pareto_expected was not declared" in report
 
 
+def test_report_distinguishes_generating_families_structural_units_and_components():
+    result = _evaluated_result()
+    truth = {
+        "name": "declaration semantics",
+        "structural_expected": 2,
+        "families_expected": [["f1", "f2", "f3", "f4"]],
+        "blocks_expected": [["f1", "f2"], ["f3", "f4"]],
+        "components_expected": [["f1", "f2"], ["f3", "f4"]],
+    }
+    report = misda.benchmark(result, truth).report()
+
+    assert "Generating families : {f1, f2, f3, f4}" in report
+    assert "Structural units    : {f1, f2} | {f3, f4}" in report
+    assert "Expected components : {f1, f2} | {f3, f4}" in report
+    assert "Expected blocks:" not in report
+
+
 def test_report_states_when_candidate_families_were_not_evaluated():
     data = np.eye(6, 4)
     result = misda.discover(data, seed=7)

--- a/tests/test_diagnostic_problems.py
+++ b/tests/test_diagnostic_problems.py
@@ -29,6 +29,15 @@ def test_clean_generation_is_explicit_identity_observation(problem):
     assert dataset.truth["problem_id"] == problem.id
     assert dataset.truth["latent_expected"] == problem.scenario.latent_expected
     assert dataset.truth["structural_expected"] == problem.scenario.structural_expected
+    assert [len(group) for group in dataset.truth["families_expected"]] == list(
+        problem.scenario.family_sizes
+    )
+    if problem.scenario.structural_unit_sizes is None:
+        assert "blocks_expected" not in dataset.truth
+    else:
+        assert [len(group) for group in dataset.truth["blocks_expected"]] == list(
+            problem.scenario.structural_unit_sizes
+        )
 
 
 @pytest.mark.parametrize("problem", PROBLEMS, ids=lambda p: p.id)

--- a/tests/test_diagnostic_scenarios.py
+++ b/tests/test_diagnostic_scenarios.py
@@ -20,20 +20,33 @@ def test_diagnostic_spec_agrees_with_legacy_generator(scenario):
     assert scenario.latent_expected >= 1
     assert scenario.structural_expected >= 1
     assert sum(scenario.family_sizes) == 20
+    if scenario.structural_unit_sizes is not None:
+        assert sum(scenario.structural_unit_sizes) == 20
+        assert len(scenario.structural_unit_sizes) == scenario.structural_expected
     scenario.validate_legacy_contract(N=32, seed=123)
 
 
-def test_generating_families_are_not_used_as_structural_dimension():
+def test_generating_families_are_not_used_as_structural_dimension_or_units():
     chain = DIAGNOSTIC_BY_ID["transitive_chain"]
     tradeoff = DIAGNOSTIC_BY_ID["tradeoff_redundancies"]
 
     # One cumulative generating family contains 20 independent innovations.
     assert chain.family_sizes == (20,)
     assert chain.structural_expected == 20
+    assert chain.structural_unit_sizes == (1,) * 20
 
-    # Three functional families are driven by a 2D structural truth.
+    # Three functional families are driven by a 2D structural truth, but do not
+    # define an unambiguous two-unit structural partition.
     assert tradeoff.family_sizes == (7, 7, 6)
     assert tradeoff.structural_expected == 2
+    assert tradeoff.structural_unit_sizes is None
+
+
+def test_overlapping_factors_do_not_declare_family_partition_as_structural_units():
+    overlapping = DIAGNOSTIC_BY_ID["overlapping_factors"]
+    assert overlapping.family_sizes == (10, 4, 6)
+    assert overlapping.structural_expected == 2
+    assert overlapping.structural_unit_sizes is None
 
 
 def test_case5_innovations_are_declared_as_structure_not_observation_noise():

--- a/tests/test_diagnostic_truth.py
+++ b/tests/test_diagnostic_truth.py
@@ -18,6 +18,34 @@ def test_pareto_truth_is_available_for_every_clean_diagnostic_problem():
         assert all(0 <= index < 48 for index in truth["pareto_expected"])
 
 
+def test_generating_families_are_declared_for_every_diagnostic_problem():
+    for problem in PROBLEMS:
+        dataset = problem.generate(N=24, seed=123, sigma=0.0)
+        truth = diagnostic_truth(problem, dataset.Z)
+        assert [len(group) for group in truth["families_expected"]] == list(
+            problem.scenario.family_sizes
+        )
+
+
+def test_case5_family_and_structural_units_are_distinct_declarations():
+    problem = PROBLEM_BY_ID["transitive_chain"]
+    dataset = problem.generate(N=32, seed=123, sigma=0.0)
+    truth = diagnostic_truth(problem, dataset.Z)
+
+    assert [len(group) for group in truth["families_expected"]] == [20]
+    assert [len(group) for group in truth["blocks_expected"]] == [1] * 20
+    assert truth["expected_mismatches"]["selected_structural_units"] == "TRANSITIVE_CHAINING"
+
+
+def test_mop_b_families_do_not_become_structural_units():
+    problem = PROBLEM_BY_ID["tradeoff_redundancies"]
+    dataset = problem.generate(N=32, seed=123, sigma=0.0)
+    truth = diagnostic_truth(problem, dataset.Z)
+
+    assert [len(group) for group in truth["families_expected"]] == [7, 7, 6]
+    assert "blocks_expected" not in truth
+
+
 def test_pareto_truth_does_not_change_when_observation_noise_changes():
     problem = PROBLEM_BY_ID["monotonic_redundancy"]
     clean = problem.generate(N=64, seed=123, sigma=0.0, observation_seed=1)


### PR DESCRIPTION
## Summary

Fixes the semantic conflation introduced during R5 between generating families, structural units, and graph connected components.

The controlled diagnostic layer now treats these as three independent declarations:

- `families_expected`: theoretical generating families;
- `blocks_expected`: structural units, preserving the existing public benchmark contract;
- `components_expected`: expected graph connected components, only when explicitly justified.

## Key cases

- **Case 5 / `transitive_chain`**: one generating family of 20 objectives, but 20 singleton structural units. The current estimator still returns 1/1 and the mismatch remains explicitly diagnostic-backed by `TRANSITIVE_CHAINING`.
- **MOP-B / `tradeoff_redundancies`**: three generating families (7/7/6), structural truth 2, but no unambiguous two-unit structural partition is declared. The benchmark therefore reports generating families while leaving structural units undeclared rather than fabricating a partition.
- **MOP-E / `overlapping_factors`** follows the same rule because its three overlapping generating families do not define a two-unit structural partition.

## Reporting

The declaration section now labels the concepts explicitly as:

- `Generating families`
- `Structural units`
- `Expected components`

`components_expected` remains legitimately N/A when no independent topology declaration exists.

## Compatibility

`blocks_expected` remains the public structural-unit field used by external benchmark callers. The new `DiagnosticScenario.structural_unit_sizes` field is optional with default `None`, preserving existing constructor usage.

No discovery, ranking, dimensional estimator, Pareto metric, or evaluation algorithm is changed.

## Validation

A pre-PR acceptance run was performed on a validation-only branch containing the exact issue-42 patch plus temporary CI-trigger accommodations. Acceptance gate **#129** passed completely:

- full test suite passed;
- clean diagnostic scientific battery passed under `--strict`;
- diagnostic comparison passed;
- benchmark artifacts were preserved successfully.

The actual PR branch contains no validation-only workflow or workflow-test changes.

Closes #42